### PR TITLE
NO-29  Optmize some parts of the Engine

### DIFF
--- a/engine/source/gfx/source/src/Animator_controller.cpp
+++ b/engine/source/gfx/source/src/Animator_controller.cpp
@@ -370,8 +370,7 @@ void gfx::Animator_controller::update(const float dt)
 gfx::Animator_state & gfx::Animator_controller::get_current_state()
 {
 	std::map<string_id, Animator_state>::iterator it = m_state_machine.find(m_current_state_id);
-	assert(it != m_state_machine.end());
-
+	//assert(it != m_state_machine.end());
 	return it->second;	
 }
 

--- a/engine/source/gfx/source/src/Graphics_manager.cpp
+++ b/engine/source/gfx/source/src/Graphics_manager.cpp
@@ -506,6 +506,7 @@ void gfx::Graphics_manager::render()
 	Texture_2d   *ptexture = static_cast<Texture_2d*>(g_texture_2d_mgr.get_by_id(text_id));
 	ptexture->use();
 	m_pmap_batch->render();
+    glBindTexture(GL_TEXTURE_2D, 0);
 
 	//render the sprites
 	//set_current_shader_program(m_sprite_shader_id);

--- a/engine/source/gfx/source/src/Sprite_batch.cpp
+++ b/engine/source/gfx/source/src/Sprite_batch.cpp
@@ -77,27 +77,30 @@ void gfx::Sprite_batch::add(const gfx::Sprite  *psprite)
 	const math::vec3  *position			=  psprite->get_vertex_position_vec();
 	const math::vec2  *texture_coord	=  psprite->get_vertex_uv_vec();
 
-	const std::size_t vec_sz = 6; // sprites allways have 6 vertices
+	const std::size_t vec_sz = VERTICES_PER_SPRITE;
 
 	if ((m_max_num_vertices - m_num_used_vertices) < vec_sz) {
 		std::cout << __FUNCTION__ << " there is not enough room for " << vec_sz << " vertices in this batch. This batch already have "
 			<< m_num_used_vertices << " vertices and can only store " << m_max_num_vertices << std::endl;
 	}
 	else {
-		std::vector<Vertex1P1C1UV> vertices; //change this!! it involvers dynamic memory allocation, maybe add a data member to Sprite_batch
+		//std::vector<Vertex1P1C1UV> vertices; //change this!! it involvers dynamic memory allocation, maybe add a data member to Sprite_batch
 		for (int i = 0; i < vec_sz; ++i) {
-			Vertex1P1C1UV vertex(position[i], math::vec4(), texture_coord[i]);
-			vertices.push_back(vertex);
+			//Vertex1P1C1UV vertex(position[i], math::vec4(), texture_coord[i]);
+			//vertices.push_back(vertex);
+            m_sprite_aux_buffer[i].m_pos = position[i];
+            m_sprite_aux_buffer[i].m_col = math::vec4();
+            m_sprite_aux_buffer[i].m_uv = texture_coord[i];
 		}
 		//transfer data to vbo
 		glBindVertexArray(m_vao);
 		glBindBuffer(GL_ARRAY_BUFFER, m_vbo);
 
-		glBufferSubData(GL_ARRAY_BUFFER, m_num_used_vertices * sizeof(Vertex1P1C1UV), vertices.size() * sizeof(Vertex1P1C1UV), &vertices[0]);
+		glBufferSubData(GL_ARRAY_BUFFER, m_num_used_vertices * sizeof(Vertex1P1C1UV), vec_sz * sizeof(Vertex1P1C1UV), &m_sprite_aux_buffer[0]);
 
 		glBindVertexArray(0);
 
-		m_num_used_vertices += vertices.size();
+		m_num_used_vertices += vec_sz;
 
 	}
 }

--- a/engine/source/gfx/source/src/Sprite_batch.hpp
+++ b/engine/source/gfx/source/src/Sprite_batch.hpp
@@ -1,8 +1,11 @@
 #ifndef _SPRITE_BATCH_HPP
 
 #define _SPRITE_BATCH_HPP
+
+#define VERTICES_PER_SPRITE 6
 #include <vector>
 #include <cstdint>
+#include "Vertex1P1C1UV.hpp"
 
 /*Sprite_batch: part of the graphics system, this class is responsable for
  * creating a vao for rendering a group of sprites.
@@ -27,6 +30,7 @@ namespace gfx {
 	private:
 		std::uint32_t	m_max_num_vertices;
 		std::uint32_t	m_num_used_vertices;
+        Vertex1P1C1UV   m_sprite_aux_buffer[VERTICES_PER_SPRITE];
 		std::uint32_t	m_vao;
 		std::uint32_t	m_vbo;
 		bool			m_is_static;

--- a/engine/source/gfx/source/src/Texture_2d.cpp
+++ b/engine/source/gfx/source/src/Texture_2d.cpp
@@ -7,7 +7,6 @@
 #include <GL/glew.h>
 #include <GLFW/glfw3.h>
 
-//#include "SOIL.h"
 #define STB_IMAGE_IMPLEMENTATION
 #include "stb_image.h"
 
@@ -173,13 +172,13 @@ gfx::Texture_2d::~Texture_2d()
 
 void gfx::Texture_2d::use(const std::uint32_t unit) const
 {
-	if (glIsTexture(m_texture_id) == GL_TRUE) {
+	//if (glIsTexture(m_texture_id) == GL_TRUE) {
 		glActiveTexture(GL_TEXTURE0 + unit);
 		glBindTexture(GL_TEXTURE_2D, m_texture_id);
-	}
-	else {
-		std::cerr << __FUNCTION__ << " failed to use texture: " << m_texture_id << " is not a name of a texture, use load_texture(image_path) to load a 2d texture" << std::endl;
-	}
+	// }
+	// else {
+	// 	std::cerr << __FUNCTION__ << " failed to use texture: " << m_texture_id << " is not a name of a texture, use load_texture(image_path) to load a 2d texture" << std::endl;
+	// }
 }
 
 

--- a/engine/source/gom/source/src/Level_manager.cpp
+++ b/engine/source/gom/source/src/Level_manager.cpp
@@ -78,12 +78,16 @@ namespace gom
 
                 m_camera.init(tile_wld_width, tile_wld_height, gfx::g_graphics_mgr.get_tiles_per_screen_width(), gfx::g_graphics_mgr.get_tiles_per_screen_height(), m_ptile_map->width(), m_ptile_map->height(), map_origin);
 
-                m_pmap_shader->uniform_matrix4fv(m_pmap_shader->get_uniform_location("V"), 1, false, m_camera.get_view().value_ptr());
+                m_tile_map_view_loc = m_pmap_shader->get_uniform_location("V");
+
+                m_pmap_shader->uniform_matrix4fv(m_tile_map_view_loc, 1, false, m_camera.get_view().value_ptr());
                 m_pmap_shader->uniform_matrix4fv(m_pmap_shader->get_uniform_location("P"), 1, false, m_camera.projection().value_ptr());
                 m_pmap_shader->uniform_1f(m_pmap_shader->get_uniform_location("tileset1"), 0);
                 gfx::g_graphics_mgr.set_tile_map_shader(m_pmap_shader);
 
-                m_psprite_shader->uniform_matrix4fv(m_psprite_shader->get_uniform_location("V"), 1, false, m_camera.get_view().value_ptr());
+                m_sprites_view_loc = m_psprite_shader->get_uniform_location("V");
+
+                m_psprite_shader->uniform_matrix4fv(m_sprites_view_loc, 1, false, m_camera.get_view().value_ptr());
                 m_psprite_shader->uniform_matrix4fv(m_psprite_shader->get_uniform_location("P"), 1, false, m_camera.projection().value_ptr());
                 m_psprite_shader->uniform_1f(m_psprite_shader->get_uniform_location("tileset"), 0);
                 gfx::g_graphics_mgr.set_sprite_shader(m_psprite_shader);
@@ -111,7 +115,8 @@ namespace gom
 
         void Level_manager::tick()
         {
-                std::cout << "FPS: " << m_timer.get_fps() << std::endl;
+                //std::cout << "FPS: " << m_timer.get_fps() << std::endl;
+               //std::cout << "FRAME TIME: " << m_timer.get_dt() << std::endl;
 
                 m_timer.update();
                 m_lag += m_timer.get_dt();
@@ -123,13 +128,13 @@ namespace gom
                         m_should_restart = true;
                 }
 
-                bool  lagging = (frame_time > m_dt) ? true : false;
-                if (lagging) {
-                        std::cout << "WE ARE BEHIND SCHEDULE by !!!!! " << (frame_time - m_dt) * 1000.0f << std::endl;
-                }
-                else {
-                        std::cout << "WE ARE ON SCHEDULE" << std::endl;
-                }
+                //bool  lagging = (frame_time > m_dt) ? true : false;
+                //if (lagging) {
+                //        std::cout << "WE ARE BEHIND SCHEDULE by !!!!! " << (frame_time - m_dt) * 1000.0f << std::endl;
+                //}
+                //else {
+                //        std::cout << "WE ARE ON SCHEDULE" << std::endl;
+                //}
 
                 while (m_lag >= m_dt) {
                         physics_2d::g_physics_mgr.get_world()->update(m_timer.get_fixed_dt());
@@ -143,7 +148,7 @@ namespace gom
                 //update the level's camera
                 m_camera.update(m_timer.get_dt());
 
-                m_pmap_shader->uniform_matrix4fv(m_pmap_shader->get_uniform_location("V"), 1, false, m_camera.get_view().value_ptr());
+                m_pmap_shader->uniform_matrix4fv(m_tile_map_view_loc, 1, false, m_camera.get_view().value_ptr());
 
                 gfx::g_graphics_mgr.get_framebuffer_size(&m_curr_vport_width, &m_curr_vport_height);
 
@@ -167,7 +172,7 @@ namespace gom
                         m_prev_vport_height = m_curr_vport_height;
                 }
 
-                m_psprite_shader->uniform_matrix4fv(m_psprite_shader->get_uniform_location("V"), 1, false, m_camera.get_view().value_ptr());
+                m_psprite_shader->uniform_matrix4fv(m_sprites_view_loc, 1, false, m_camera.get_view().value_ptr());
 
                 gfx::g_graphics_mgr.render();
 

--- a/engine/source/gom/source/src/Level_manager.hpp
+++ b/engine/source/gom/source/src/Level_manager.hpp
@@ -40,6 +40,8 @@ namespace gom
                 int                                             m_prev_vport_height;
                 int                                             m_curr_vport_width;
                 int                                             m_curr_vport_height;
+                int32_t                                         m_sprites_view_loc;
+                int32_t                                         m_tile_map_view_loc;
                 bool                                            m_should_restart;
 
         };


### PR DESCRIPTION
 There was room to optmizations on the Sprite_batch class, Texture_2d class, and on the use of the shaders.
 - Sprite_batch was making dynamic memory allocations inside a loop
 - Texture_2d class was making a unecesary verification on the user function
 - The call to shader::get_uniform_location on every update was decreasing the performance