### PR TITLE
NO-27 Pause game state implementation and Timer class refactor

### DIFF
--- a/engine/source/gfx/source/src/Graphics_manager.hpp
+++ b/engine/source/gfx/source/src/Graphics_manager.hpp
@@ -7,7 +7,6 @@
 
 #include "Pool_allocator.hpp"
 #include "string_id.hpp"
-//#include "Camera_2d.hpp"
 
 #if GRAPHICS_CONSOLE_DEBUG_ENABLE
 

--- a/engine/source/gom/source/CMakeLists.txt
+++ b/engine/source/gom/source/CMakeLists.txt
@@ -10,5 +10,6 @@ SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 SET(INCLUDE_FILES  src/Game_object.hpp src/Projectile.hpp src/Projectile_manager.hpp  src/Actor.hpp src/Enemy.hpp src/Game_object_data.hpp src/Creator.hpp src/Camera_2d.hpp src/Gameplay_state.hpp src/Game_object_handle.hpp src/Game_object_manager.hpp src/Level_manager.hpp)
 SET(SOURCE_FILES  src/Game_object.cpp  src/Projectile.cpp src/Projectile_manager.cpp  src/Actor.cpp src/Enemy.cpp src/Creator.cpp src/Camera_2d.cpp src/Game_object_handle.cpp src/Game_object_manager.cpp src/Level_manager.cpp)
 
+INCLUDE_DIRECTORIES(${GLFW3_INCLUDE_DIR} ${GLEW_INCLUDE_DIR} ${OPENGL_INCLUDE_DIR})
 ADD_LIBRARY(gom OBJECT ${INCLUDE_FILES} ${SOURCE_FILES})
 TARGET_INCLUDE_DIRECTORIES( gom PUBLIC ${MATH_INCLUDE_DIR} ${MEM_INCLUDE_DIR} ${RMS_INCLUDE_DIR} ${UTILITY_INCLUDE_DIR} ${TMAP_INCLUDE_DIR} ${IO_INCLUDE_DIR} ${GFX_INCLUDE_DIR} ${PHY_2D_INCLUDE_DIR})

--- a/engine/source/gom/source/src/Level_manager.hpp
+++ b/engine/source/gom/source/src/Level_manager.hpp
@@ -1,6 +1,7 @@
 #ifndef _LEVEL_MANAGER_HPP
 #define _LEVEL_MANAGER_HPP
 #include <vector>
+#include <stdint.h>
 #include "Path.hpp"
 #include "Timer.hpp"
 #include "Camera_2d.hpp"
@@ -21,6 +22,7 @@ namespace gom
                 void tick();
                 void restart();
                 Camera_2d & get_camera();
+                bool is_game_clock_paused() const { return m_timer.is_paused(); }
                 //void next_level();
         private:
                 void            load_level_objects();
@@ -32,6 +34,9 @@ namespace gom
                 gfx::Shader*                                    m_psprite_shader;
                 gfx::Shader*                                    m_pmap_shader;
                 Timer                                           m_timer;
+                uint64_t                                        m_last_time_cycles;
+                uint64_t                                        m_curr_time_cycles;
+                float                                           m_delta_time_seconds;
                 float                                           m_lag;
                 static const float                              m_dt;
                 float                                           m_target_aspect_ratio;

--- a/engine/source/io/source/src/input_manager.cpp
+++ b/engine/source/io/source/src/input_manager.cpp
@@ -230,6 +230,9 @@ namespace io {
 #endif // !NDEBUG
                 button.m_bound_key = KEY_R;
                 break;
+        case GLFW_KEY_P:
+                button.m_bound_key = KEY_P;
+                break;
         default:
 			std::cerr << __FUNCTION__ << " : unkown keycode" << std::endl;
 			return;
@@ -258,9 +261,9 @@ namespace io {
 			break;
 		}
 
-#ifndef NDEBUG
-		//std::cout << __FUNCTION__ << " DEBUG: " << "key: " << key_name << " | action: " << action_name << std::endl;
-#endif // !NDEBUG
+// #ifndef NDEBUG
+// 		std::cout << __FUNCTION__ << " DEBUG: " << "key: " << key_name << " | action: " << action_name << std::endl;
+// #endif // !NDEBUG
 
 		buttons[button.m_bound_key].update(new_action);
 		/*

--- a/engine/source/io/source/src/input_manager.hpp
+++ b/engine/source/io/source/src/input_manager.hpp
@@ -11,7 +11,7 @@
  *
  */
 namespace io {
-	enum KEYS { KEY_W = 0, KEY_A, KEY_S, KEY_D, KEY_LEFT, KEY_RIGHT, KEY_DOWN, KEY_UP, KEY_ENTER, KEY_SPACE, KEY_Q, KEY_R, INVALID_KEY };
+	enum KEYS { KEY_W = 0, KEY_A, KEY_S, KEY_D, KEY_P, KEY_B, KEY_LEFT, KEY_RIGHT, KEY_DOWN, KEY_UP, KEY_ENTER, KEY_SPACE, KEY_Q, KEY_R, INVALID_KEY };
 	enum GAME_ACTIONS { JUMP = 0, CLIMB_UP, CLIMB_DOWN, MOVE_LEFT, MOVE_RIGHT, MOVE_UP, MOVE_DOWN, ATTACK_01, ATTACK_02, ATTACK_03, ATTACK_04, START, PAUSE, QUIT, RESET };
 	extern void key_callback(int key, int scancode, int action, int mods);
 	extern void map_action_to_button(const int action, const Button & button);

--- a/engine/source/utility/source/src/Timer.cpp
+++ b/engine/source/utility/source/src/Timer.cpp
@@ -1,35 +1,43 @@
 #include "Timer.hpp"
 
-#define GLEW_STATIC
-#include <GL/glew.h>
-#include <GLFW/glfw3.h>
+ #define GLEW_STATIC
+ #include <GL/glew.h>
+ #include <GLFW/glfw3.h>
 
 
 
+float Timer::s_fixed_delta_time_seconds;
+float Timer::s_cycles_per_second;
 
-void Timer::init(float ms_per_update) 
+void Timer::init()
 {
-	m_fixed_dt = ms_per_update;
-	m_last_time = glfwGetTime();
+        s_cycles_per_second = static_cast<float>(glfwGetTimerFrequency());
+        s_fixed_delta_time_seconds = 1.0f / 60.0f;
 }
 
-void Timer::update() 
+
+void Timer::update(float dt_real_seconds) 
 {
-	m_current_time = glfwGetTime();
-	m_delta_time = m_current_time - m_last_time;
-	m_last_time = m_current_time;
-	// the overall time elapsed since init
-	m_time			+=   m_delta_time;
-#ifndef NDEBUG
-	m_fps_time += m_delta_time;
-	if (m_fps_time > 0.9999f) {
-		m_curr_fps = m_fps_cnt;
-		m_fps_time -= 0.9999f;
-		m_fps_cnt = 1;
-	}
-	else {
-		++m_fps_cnt;
-	}
-#endif // !NDEBUG
+        if (!m_is_paused) {
+                uint64_t dt_scaled_cycles = seconds_to_cycles(dt_real_seconds * m_time_scale);
+                m_time_cycles += dt_scaled_cycles;
+        }
+        
+	// m_current_time = glfwGetTime();
+	// m_delta_time = m_current_time - m_last_time;
+	// m_last_time = m_current_time;
+	// // the overall time elapsed since init
+	// m_time			+=   m_delta_time;
+// #ifndef NDEBUG
+// 	m_fps_time += m_delta_time;
+// 	if (m_fps_time > 0.9999f) {
+// 		m_curr_fps = m_fps_cnt;
+// 		m_fps_time -= 0.9999f;
+// 		m_fps_cnt = 1;
+// 	}
+// 	else {
+// 		++m_fps_cnt;
+// 	}
+// #endif // !NDEBUG
 
 }

--- a/engine/source/utility/source/src/Timer.hpp
+++ b/engine/source/utility/source/src/Timer.hpp
@@ -1,27 +1,39 @@
 #ifndef _TIMER_HPP
 #define _TIMER_HPP
-
-//The global clock of the engine, every system that needs to acess the time, should do it through this class
-
-#define DEFAULT_MS_PER_UPDATE 1/60.0F
+#include <stdint.h>
 
 class Timer{
 public:
-	Timer() : m_last_time(0.0f), m_current_time(0.0f), m_delta_time(0.0f), m_time(0.0f), m_curr_fps(0), m_fps_cnt(0), m_fps_time(0.0f) {}
-	~Timer() = default;
+        explicit Timer(float start_time_seconds = 0.0) : m_time_cycles(seconds_to_cycles(start_time_seconds)), m_time_scale(1.0f), m_is_paused(false) {}
+        ~Timer() = default;
 	
-	void           init(float ms_per_update = DEFAULT_MS_PER_UPDATE);
-	void		   update();
-	float		   get_time()     const  { return m_time; }
-	float		   get_dt()       const  { return m_delta_time;}
-	float          get_fixed_dt() const  { return m_fixed_dt; }
-	int            get_fps()  const { return m_curr_fps; }
+    static void    init();
+    void           update(float dt_real_seconds);
+    uint64_t       get_time_cycles() const { return m_time_cycles; }
+    bool           is_paused() const { return m_is_paused; }
+    void           set_paused(bool want_paused) { m_is_paused = want_paused; }
+    float          get_time_scale() const { return m_time_scale; }
+    void           set_time_scale(float scale) { m_time_scale = scale; }
+    static inline  float   get_fixed_delta_time_seconds() { return s_fixed_delta_time_seconds; }
+
+    static inline  uint64_t seconds_to_cycles(float time_seconds)
+    {
+            return static_cast<uint64_t>(time_seconds * s_cycles_per_second);
+    }
+
+    static inline float cycles_to_seconds(uint64_t time_cycles)
+    {
+            return static_cast<float>(time_cycles) / s_cycles_per_second;
+    }
+    int            get_fps()  const { return m_curr_fps; }
 private:
-	float m_fixed_dt;
-	float m_current_time;
-	float m_last_time;
-	float m_delta_time;
-	float m_time;    // time measured since first update call
+	
+        uint64_t    m_time_cycles;
+        float       m_time_scale;
+        bool        m_is_paused;
+
+    static      float s_fixed_delta_time_seconds;
+    static      float s_cycles_per_second;
 	
 	int   m_fps_cnt;
 	int   m_curr_fps; // a frames per second counter

--- a/game/source/src/Player.cpp
+++ b/game/source/src/Player.cpp
@@ -12,6 +12,7 @@
 #include "Animator_controller.hpp"
 #include "Sprite.hpp"
 #include "Body_2d.hpp"
+#include "Level_manager.hpp"
 
 
 Player::Player(const game_object_id unique_id, const uint16_t handle_index, atlas_n_layer & sprite_data, physics_2d::Body_2d_def *pbody_def, const gfx::Animator_controller *pcontroller, bool facing_left) :
@@ -43,9 +44,10 @@ void Player::actor_collision(gom::Actor *pactor)
 
 void Player::update(const float dt) 
 {
-	handle_input();
+        if (!gom::g_level_mgr.is_game_clock_paused()) {
+                handle_input();
+        }
 	m_panimator_controller->update(dt);
-	
 	gfx::Animator_state & curr_state = m_panimator_controller->get_current_state();
 	if (curr_state.changed_animation_frame()) {
 		m_psprite->update_uv(curr_state.get_curr_anim_frame());


### PR DESCRIPTION
- [x] There should be a key mapped to the pause game state, so that when the user presses this key, the **game's clock** enters a pausing state. In this state, the game loop will continue to run, but all the systems in the engine should not advance the simulation, since it's clock is currently paused. The 'key' here is the **Timer class**, it  needs to be refactored to better accommodate the pausing state.
 
It was necessary to refactor the Timer class to be able to implement the game's pausing state.  Now, the timer has a function to pause itself, it also uses the high resolution timer, storing its value on a 64-bit unsigned variable and, is now better suited to implement other features such as time scaling and single frame stepping.

[Ticket](https://app.hacknplan.com/p/68474/kanban?categoryId=0&boardId=198827&taskId=27&tabId=basicinfo)