### PR TITLE
NO-32 Implement  Glfw_manager and Window classes

### DIFF
--- a/engine/source/gfx/source/CMakeLists.txt
+++ b/engine/source/gfx/source/CMakeLists.txt
@@ -7,8 +7,8 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 #Using c++11
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
-SET(INCLUDE_FILES  src/Shader.hpp src/Shader_manager.hpp src/Texture_2d.hpp src/Texture_2d_manager.hpp src/Vertex1P1C1UV.hpp src/Sprite_atlas.hpp  src/Sprite.hpp   src/Sprite_atlas_manager.hpp src/Animation.hpp src/Animation_player.hpp src/Animator_controller_parameter.hpp src/Animator_controller.hpp src/Animator_state.hpp src/Animator_state_transition.hpp src/Animator_condition src/Sprite_batch.hpp src/Graphics_manager.hpp)
-SET(SOURCE_FILES   src/Shader.cpp src/Shader_manager.cpp src/Texture_2d.cpp src/Texture_2d_manager.cpp src/Sprite_atlas.cpp src/Sprite.cpp  src/Sprite_atlas_manager.cpp src/Animation_player.cpp src/Animator_controller_parameter.cpp src/Animator_controller.cpp src/Animator_state.cpp src/Animator_state_transition.cpp src/Sprite_batch.cpp src/Graphics_manager.cpp)
+SET(INCLUDE_FILES  src/Shader.hpp src/Shader_manager.hpp src/Texture_2d.hpp src/Texture_2d_manager.hpp src/Vertex1P1C1UV.hpp src/Sprite_atlas.hpp  src/Sprite.hpp   src/Sprite_atlas_manager.hpp src/Animation.hpp src/Animation_player.hpp src/Animator_controller_parameter.hpp src/Animator_controller.hpp src/Animator_state.hpp src/Animator_state_transition.hpp src/Animator_condition src/Sprite_batch.hpp src/Window.hpp src/Graphics_manager.hpp)
+SET(SOURCE_FILES   src/Shader.cpp src/Shader_manager.cpp src/Texture_2d.cpp src/Texture_2d_manager.cpp src/Sprite_atlas.cpp src/Sprite.cpp  src/Sprite_atlas_manager.cpp src/Animation_player.cpp src/Animator_controller_parameter.cpp src/Animator_controller.cpp src/Animator_state.cpp src/Animator_state_transition.cpp src/Sprite_batch.cpp src/Window.cpp src/Graphics_manager.cpp)
 
 ADD_LIBRARY(gfx OBJECT ${INCLUDE_FILES} ${SOURCE_FILES})
 

--- a/engine/source/gfx/source/CMakeLists.txt
+++ b/engine/source/gfx/source/CMakeLists.txt
@@ -7,9 +7,27 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 #Using c++11
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
-SET(INCLUDE_FILES  src/Shader.hpp src/Shader_manager.hpp src/Texture_2d.hpp src/Texture_2d_manager.hpp src/Vertex1P1C1UV.hpp src/Sprite_atlas.hpp  src/Sprite.hpp   src/Sprite_atlas_manager.hpp src/Animation.hpp src/Animation_player.hpp src/Animator_controller_parameter.hpp src/Animator_controller.hpp src/Animator_state.hpp src/Animator_state_transition.hpp src/Animator_condition src/Sprite_batch.hpp src/Window.hpp src/Graphics_manager.hpp)
-SET(SOURCE_FILES   src/Shader.cpp src/Shader_manager.cpp src/Texture_2d.cpp src/Texture_2d_manager.cpp src/Sprite_atlas.cpp src/Sprite.cpp  src/Sprite_atlas_manager.cpp src/Animation_player.cpp src/Animator_controller_parameter.cpp src/Animator_controller.cpp src/Animator_state.cpp src/Animator_state_transition.cpp src/Sprite_batch.cpp src/Window.cpp src/Graphics_manager.cpp)
+SET(INCLUDE_FILES  src/Shader.hpp src/Shader_manager.hpp src/Texture_2d.hpp
+                   src/Texture_2d_manager.hpp src/Vertex1P1C1UV.hpp src/Sprite_atlas.hpp
+		   src/Sprite.hpp src/Sprite_atlas_manager.hpp src/Animation.hpp
+		   src/Animation_player.hpp src/Animator_controller_parameter.hpp
+		   src/Animator_controller.hpp src/Animator_state.hpp
+		   src/Animator_state_transition.hpp src/Animator_condition
+		   src/Sprite_batch.hpp src/Window.hpp src/Glfw_manager.hpp
+		   src/Graphics_manager.hpp)
+
+SET(SOURCE_FILES   src/Shader.cpp src/Shader_manager.cpp src/Texture_2d.cpp
+                   src/Texture_2d_manager.cpp src/Sprite_atlas.cpp src/Sprite.cpp
+		   src/Sprite_atlas_manager.cpp src/Animation_player.cpp
+		   src/Animator_controller_parameter.cpp src/Animator_controller.cpp
+		   src/Animator_state.cpp src/Animator_state_transition.cpp
+		   src/Sprite_batch.cpp src/Window.cpp src/Glfw_manager.cpp
+		   src/Graphics_manager.cpp)
 
 ADD_LIBRARY(gfx OBJECT ${INCLUDE_FILES} ${SOURCE_FILES})
 
-TARGET_INCLUDE_DIRECTORIES(gfx PUBLIC ${GLFW3_INCLUDE_DIR} ${GLEW_INCLUDE_DIR} ${OPENGL_INCLUDE_DIR} ${STB_INCLUDE_DIR} ${MATH_INCLUDE_DIR} ${MEM_INCLUDE_DIR} ${UTILITY_INCLUDE_DIR} ${TMAP_INCLUDE_DIR} ${RMS_INCLUDE_DIR})
+TARGET_INCLUDE_DIRECTORIES(gfx PUBLIC ${GLFW3_INCLUDE_DIR} ${GLEW_INCLUDE_DIR} 
+                                      ${OPENGL_INCLUDE_DIR} ${STB_INCLUDE_DIR} 
+				      ${MATH_INCLUDE_DIR} ${MEM_INCLUDE_DIR} 
+				      ${UTILITY_INCLUDE_DIR} ${TMAP_INCLUDE_DIR} 
+				      ${RMS_INCLUDE_DIR})

--- a/engine/source/gfx/source/src/Glfw_manager.cpp
+++ b/engine/source/gfx/source/src/Glfw_manager.cpp
@@ -1,0 +1,55 @@
+#include "Glfw_manager.hpp"
+#include "Window.hpp"
+
+#include <GLFW/glfw3.h>
+
+namespace gfx
+{
+        using Glfw_manager::error_callback_ptr;
+        using Glfw_manager::key_callback_ptr;
+
+        static void Glfw_manager::init()
+        {
+                glfwInit();
+        }
+
+        static void Glfw_manager::window_hint(int hint, int value)
+        {
+                glfwWindowHint(hint, value);
+        }
+
+        static Window * Glfw_manager::create_window(int width, int height, const char * ptitle)
+        {
+                return new Window(width, height, ptitle);
+        }
+
+        static void Glfw_manager::swap_interval(int interval)
+        {
+                glfwSwapInterval(interval);
+        }
+
+        static void Glfw_manager::make_context_current(Window * pwindow)
+        {
+                glfwMakeContextCurrent(pwindow->m_pglfw_window);
+        }
+
+        static void Glfw_manager::set_error_callback(error_callback_ptr pcallback)
+        {
+                glfwSetErrorCallback(pcallback);
+        }
+
+        static void Glfw_manager::set_key_callback(Window *pwindow, key_callback_ptr pcallback)
+        {
+                glfwSetKeyCallback(pwindow->m_pglfw_window, pcallback);
+        }
+
+        static void Glfw_manager::poll_events()
+        {
+                glfwPollEvents();
+        }
+
+        static void Glfw_manager::terminate()
+        {
+                glfwTerminate();
+        }
+}

--- a/engine/source/gfx/source/src/Glfw_manager.cpp
+++ b/engine/source/gfx/source/src/Glfw_manager.cpp
@@ -5,9 +5,6 @@
 
 namespace gfx
 {
-        using Glfw_manager::error_callback_ptr;
-        using Glfw_manager::key_callback_ptr;
-
         void Glfw_manager::init(int context_version_major, int context_version_minor)
         {
                 glfwInit();
@@ -19,42 +16,42 @@ namespace gfx
                 glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
         }
 
-        static void Glfw_manager::window_hint(int hint, int value)
+        void Glfw_manager::window_hint(int hint, int value)
         {
                 glfwWindowHint(hint, value);
         }
 
-        static Window * Glfw_manager::create_window(int width, int height, const char * ptitle)
+        Window * Glfw_manager::create_window(int width, int height, const char * ptitle)
         {
                 return new Window(width, height, ptitle);
         }
 
-        static void Glfw_manager::swap_interval(int interval)
+        void Glfw_manager::swap_interval(int interval)
         {
                 glfwSwapInterval(interval);
         }
 
-        static void Glfw_manager::make_context_current(Window * pwindow)
+        void Glfw_manager::make_context_current(Window * pwindow)
         {
                 glfwMakeContextCurrent(pwindow->m_pglfw_window);
         }
 
-        static void Glfw_manager::set_error_callback(error_callback_ptr pcallback)
+        void Glfw_manager::set_error_callback(error_callback_ptr pcallback)
         {
                 glfwSetErrorCallback(pcallback);
         }
 
-        static void Glfw_manager::set_key_callback(Window *pwindow, key_callback_ptr pcallback)
+        void Glfw_manager::set_key_callback(Window *pwindow, key_callback_ptr pcallback)
         {
                 glfwSetKeyCallback(pwindow->m_pglfw_window, pcallback);
         }
 
-        static void Glfw_manager::poll_events()
+        void Glfw_manager::poll_events()
         {
                 glfwPollEvents();
         }
 
-        static void Glfw_manager::terminate()
+        void Glfw_manager::terminate()
         {
                 glfwTerminate();
         }

--- a/engine/source/gfx/source/src/Glfw_manager.cpp
+++ b/engine/source/gfx/source/src/Glfw_manager.cpp
@@ -8,9 +8,15 @@ namespace gfx
         using Glfw_manager::error_callback_ptr;
         using Glfw_manager::key_callback_ptr;
 
-        static void Glfw_manager::init()
+        void Glfw_manager::init(int context_version_major, int context_version_minor)
         {
                 glfwInit();
+                glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, context_version_major);
+                glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, context_version_minor);
+                // Use a forward-compatible context
+                glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
+                // Use OpenGl core profile
+                glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
         }
 
         static void Glfw_manager::window_hint(int hint, int value)

--- a/engine/source/gfx/source/src/Glfw_manager.hpp
+++ b/engine/source/gfx/source/src/Glfw_manager.hpp
@@ -12,7 +12,7 @@ namespace gfx
                 typedef void (*key_callback_ptr) (GLFWwindow *, int, int, int, int);
                 typedef void (*error_callback_ptr) (int const char *);
         public:
-                static void          init();
+                static void          init(int context_version_major, int context_version_minor);
                 static void          terminate();
                 static void          window_hint(int hint, int value);
                 static Window *      create_window(int width, int height, const char *ptitle);

--- a/engine/source/gfx/source/src/Glfw_manager.hpp
+++ b/engine/source/gfx/source/src/Glfw_manager.hpp
@@ -1,0 +1,28 @@
+#ifndef _GLFW_MANAGER_HPP
+#define _GLFW_MANAGER_HPP
+
+namespace gfx { class Window; }
+namespace gfx
+{
+        /**
+         * A wrapper for the GLFW library
+         *
+         */
+        class Glfw_manager {
+                typedef void (*key_callback_ptr) (GLFWwindow *, int, int, int, int);
+                typedef void (*error_callback_ptr) (int const char *);
+        public:
+                static void          init();
+                static void          terminate();
+                static void          window_hint(int hint, int value);
+                static Window *      create_window(int width, int height, const char *ptitle);
+                static void          swap_interval(int interval);
+                static void          make_context_current(Window * pwindow);
+                static void          poll_events();
+
+                static void         set_error_callback(error_callback_ptr pcallback);
+                static void         set_key_callback(Window *pwindow, key_callback_ptr pcallback);
+        };
+}
+
+#endif // !_GLFW_MANAGER_HPP

--- a/engine/source/gfx/source/src/Glfw_manager.hpp
+++ b/engine/source/gfx/source/src/Glfw_manager.hpp
@@ -1,6 +1,7 @@
 #ifndef _GLFW_MANAGER_HPP
 #define _GLFW_MANAGER_HPP
 
+struct GLFWwindow;
 namespace gfx { class Window; }
 namespace gfx
 {
@@ -9,9 +10,9 @@ namespace gfx
          *
          */
         class Glfw_manager {
-                typedef void (*key_callback_ptr) (GLFWwindow *, int, int, int, int);
-                typedef void (*error_callback_ptr) (int const char *);
         public:
+                typedef void(*key_callback_ptr) (GLFWwindow *, int, int, int, int);
+                typedef void(*error_callback_ptr) (int, const char *);
                 static void          init(int context_version_major, int context_version_minor);
                 static void          terminate();
                 static void          window_hint(int hint, int value);

--- a/engine/source/gfx/source/src/Graphics_manager.hpp
+++ b/engine/source/gfx/source/src/Graphics_manager.hpp
@@ -18,9 +18,8 @@
 
 #endif
 
-struct GLFWwindow;
 class  Tile_map;
-namespace gfx { class Sprite; class Shader; class Sprite_batch; }
+namespace gfx { class Window; class Sprite; class Shader; class Sprite_batch; }
 namespace math { struct vec4; }
 
 namespace gfx {
@@ -30,24 +29,15 @@ namespace gfx {
 		typedef		string_id       texture_id;
 		typedef		string_id		shader_id;
 		typedef		std::uint8_t	sprite_layer;
-
-		typedef     void (*error_callback_ptr) (int, const char*);
-		typedef     void (*key_callback_ptr)   (GLFWwindow *, int, int, int, int);
 	public:
-			        Graphics_manager();
-					~Graphics_manager() = default;
+            Graphics_manager();
+            ~Graphics_manager() = default;
 		//initialization functions
-		void		init(const std::uint8_t context_version_major, const std::uint8_t context_version_minor, const float pixels_per_unit = 16.0f);
-		bool        create_window(const std::int32_t width, const std::int32_t height, const char *ptitle);
+            bool		init(int window_width, int window_height, const char * ptitle, float pixels_per_unit = 16.0f);
+            Window  *   get_render_window();
+		//bool        create_window(const std::int32_t width, const std::int32_t height, const char *ptitle);
 		
-		// Incapsulation of OpenGl and GLFW  functions
-		bool        window_should_close() const;
-		void        set_error_callback(error_callback_ptr fptr);
-		void		set_key_callback(key_callback_ptr fptr);
-		
-		void		get_framebuffer_size(std::int32_t * pwidth, std::int32_t *pheight);
 		void        set_viewport(std::int32_t x, std::int32_t y, std::int32_t width, std::int32_t height);
-		//Camera_2d & get_camera();
 
 		void		set_clear_color(const math::vec4 & color);
 		void		set_blend_func(); // CHANGE THIS!! PASS PARAMETERS
@@ -93,11 +83,9 @@ namespace gfx {
 		//std::map<atlas_id, Sprite_atlas*>			m_atlases;
 		//std::map<shader_id, Shader*>				m_shaders;
 		//std::map<texture_id, Texture_2d*>           m_textures;
-		//Camera_2d									m_camera;
 
 		std::vector<Sprite_batch*>					m_batches;
 		std::vector<Sprite*>						m_sprites;
-		//std::map<controller_id, Animator_controller*> m_animator_controllers;
 
 		// memory allocators
 		//Pool_allocator								m_atlas_pool;
@@ -114,19 +102,14 @@ namespace gfx {
 		gfx::Shader									*m_psprite_shader; // the id for the shader used to render the sprites
 		gfx::Shader									*m_ptile_map_shader; // the id for the shader used to render the Tile map
 
-		// Opengl Context data
-		GLFWwindow		*m_pwindow; // GLFW window
-		//Opengl's context version
-		std::uint8_t	m_context_version_major; 
-		std::uint8_t	m_context_version_minor;
-
+        Window *m_prender_window;
 
 		float			m_pixels_per_unit;
 		float           m_tiles_per_screen_width;
 		float           m_tiles_per_screen_height;
 		bool			m_is_initialized;
-
 	};
+
 	extern  Graphics_manager g_graphics_mgr;
 	bool	sprite_sort(const gfx::Sprite *lhs, const gfx::Sprite *rhs);
 }

--- a/engine/source/gfx/source/src/Window.cpp
+++ b/engine/source/gfx/source/src/Window.cpp
@@ -18,6 +18,11 @@ namespace gfx
                 return std::make_pair(width, height);
         }
 
+        void Window::set_title(const char * ptitle)
+        {
+                glfwSetWindowTitle(m_pglfw_window, ptitle);
+        }
+
         bool Window::should_close() const
         {
                 return glfwWindowShouldClose(m_pglfw_window);

--- a/engine/source/gfx/source/src/Window.cpp
+++ b/engine/source/gfx/source/src/Window.cpp
@@ -5,17 +5,17 @@
 namespace gfx
 {
         Window::Window(int width, int height, const char * ptitle) : 
-                m_width(width), m_height(height), m_title(title)
+                m_width(width), m_height(height), m_title(ptitle)
         {
                 m_pglfw_window = glfwCreateWindow(width, height, ptitle, NULL, NULL);
         }
 
 
-        std::pair<int, int> Window::get_framebuffer_size()
+        std::pair<int, int> Window::get_framebuffer_size() const
         {
                 int width, height;
                 glfwGetFramebufferSize(m_pglfw_window, &width, &height);
-                return std::make_pair<int, int>(width, height);
+                return std::make_pair(width, height);
         }
 
         bool Window::should_close() const
@@ -28,7 +28,7 @@ namespace gfx
                 glfwSwapBuffers(m_pglfw_window);
         }
 
-        bool Window::is_window_initialized() const
+        bool Window::is_initialized() const
         {
                 if (m_pglfw_window) {
                         return true;

--- a/engine/source/gfx/source/src/Window.cpp
+++ b/engine/source/gfx/source/src/Window.cpp
@@ -23,6 +23,11 @@ namespace gfx
                 glfwSetWindowTitle(m_pglfw_window, ptitle);
         }
 
+        void Window::set_size(int width, int height)
+        {
+                glfwSetWindowSize(m_pglfw_window, width, height);
+        }
+
         bool Window::should_close() const
         {
                 return glfwWindowShouldClose(m_pglfw_window);

--- a/engine/source/gfx/source/src/Window.cpp
+++ b/engine/source/gfx/source/src/Window.cpp
@@ -1,0 +1,54 @@
+#include "Window.hpp"
+#include <GLFW/glfw3.h>
+
+#include <utility>
+namespace gfx
+{
+        Window::Window(int width, int height, const char * ptitle) : 
+                m_width(width), m_height(height), m_title(title)
+        {
+                m_pglfw_window = glfwCreateWindow(width, height, ptitle, NULL, NULL);
+        }
+
+
+        std::pair<int, int> Window::get_framebuffer_size()
+        {
+                int width, height;
+                glfwGetFramebufferSize(m_pglfw_window, &width, &height);
+                return std::make_pair<int, int>(width, height);
+        }
+
+        bool Window::should_close() const
+        {
+                return glfwWindowShouldClose(m_pglfw_window);
+        }
+
+        void Window::swap_buffers()
+        {
+                glfwSwapBuffers(m_pglfw_window);
+        }
+
+        bool Window::is_window_initialized() const
+        {
+                if (m_pglfw_window) {
+                        return true;
+                }
+                else {
+                        return false;
+                }
+        }
+
+        Window::~Window()
+        {
+                destroy();
+        }
+
+        void Window::destroy()
+        {
+                if (m_pglfw_window) {
+                        glfwDestroyWindow(m_pglfw_window);
+                        m_pglfw_window = nullptr;
+                }
+        }
+
+}

--- a/engine/source/gfx/source/src/Window.hpp
+++ b/engine/source/gfx/source/src/Window.hpp
@@ -30,7 +30,7 @@ namespace gfx
                 std::pair<int, int>     get_framebuffer_size() const;
                 bool                    should_close() const;
                 void                    swap_buffers();
-                bool                    is_window_initialized() const;
+                bool                    is_initialized() const;
 
         private:
                 void                    destroy();

--- a/engine/source/gfx/source/src/Window.hpp
+++ b/engine/source/gfx/source/src/Window.hpp
@@ -28,6 +28,7 @@ namespace gfx
                                         ~Window();
 
                 std::pair<int, int>     get_framebuffer_size() const;
+                void                    set_title(const char * ptitle);
                 bool                    should_close() const;
                 void                    swap_buffers();
                 bool                    is_initialized() const;

--- a/engine/source/gfx/source/src/Window.hpp
+++ b/engine/source/gfx/source/src/Window.hpp
@@ -1,0 +1,41 @@
+#ifndef _WINDOW_HPP
+#define _WINDOW_HPP
+
+#include <utility>
+#include <string>
+
+struct GLFWwindow;
+namespace gfx
+{
+        /**
+         * Handles a window with an OpenGL context that can receive input events 
+         *
+         * This class provides a window with an OpenGL context, required by 
+         * the graphics manager to render the level. It also allows the 
+         * registering of callbacks that are fired by io events on the window.
+         */
+        class Window {
+        public:
+                                        Window(int width, int height, const char * ptitle);
+                                        Window(Window &) = delete;
+                                        Window(Window &&) = delete;
+                                        
+                Window &                operator=(const Window &) = delete;
+                Window &                operator=(Window &&) = delete;
+
+                                        ~Window();
+
+                std::pair<int, int>     get_framebuffer_size() const;
+                bool                    should_close() const;
+                void                    swap_buffers();
+                bool                    is_window_initialized() const;
+
+        private:
+                void                    destroy();
+                GLFWwindow *            m_pglfw_window;
+                int                     m_width;
+                int                     m_height;
+                std::string             m_title;
+        };
+}
+#endif // !_WINDOW_HPP

--- a/engine/source/gfx/source/src/Window.hpp
+++ b/engine/source/gfx/source/src/Window.hpp
@@ -29,6 +29,7 @@ namespace gfx
 
                 std::pair<int, int>     get_framebuffer_size() const;
                 void                    set_title(const char * ptitle);
+                void                    set_size(int width, int height);
                 bool                    should_close() const;
                 void                    swap_buffers();
                 bool                    is_initialized() const;

--- a/engine/source/gfx/source/src/Window.hpp
+++ b/engine/source/gfx/source/src/Window.hpp
@@ -5,6 +5,7 @@
 #include <string>
 
 struct GLFWwindow;
+namespace gfx { class Glfw_manager; }
 namespace gfx
 {
         /**
@@ -15,6 +16,7 @@ namespace gfx
          * registering of callbacks that are fired by io events on the window.
          */
         class Window {
+                friend class Glfw_manager;
         public:
                                         Window(int width, int height, const char * ptitle);
                                         Window(Window &) = delete;

--- a/engine/source/gom/source/src/Level_manager.cpp
+++ b/engine/source/gom/source/src/Level_manager.cpp
@@ -9,6 +9,7 @@
 #include "Path.hpp"
 #include "Shader.hpp"
 #include "Shader_manager.hpp"
+#include "Window.hpp"
 #include "Graphics_manager.hpp"
 #include "Sprite_atlas.hpp"
 #include "Texture_2d_manager.hpp"               
@@ -32,6 +33,7 @@
 #include "mat4.hpp"
 
 #include <vector>
+#include <utility>
 
 namespace gom
 {
@@ -73,7 +75,13 @@ namespace gom
                 m_target_aspect_ratio = m_curr_aspect_ratio;
 
                 //set variables to control the aspect ratio if the user changes the screen dimensions
-                gfx::g_graphics_mgr.get_framebuffer_size(&m_prev_vport_width, &m_prev_vport_height);
+
+                gfx::Window * prender_window = gfx::g_graphics_mgr.get_render_window();
+                std::pair<int, int> window_dimensions = prender_window->get_framebuffer_size();
+                
+                //gfx::g_graphics_mgr.get_framebuffer_size(&m_prev_vport_width, &m_prev_vport_height);
+                m_prev_vport_width = window_dimensions.first;
+                m_prev_vport_height = window_dimensions.second;
 
                 gfx::g_graphics_mgr.set_viewport(0, 0, m_prev_vport_width, m_prev_vport_height);
                 m_curr_vport_width = m_prev_vport_width;
@@ -189,7 +197,11 @@ namespace gom
                 
                 m_pmap_shader->uniform_matrix4fv(m_tile_map_view_loc, 1, false, m_camera.get_view().value_ptr());
 
-                gfx::g_graphics_mgr.get_framebuffer_size(&m_curr_vport_width, &m_curr_vport_height);
+                gfx::Window * prender_window = gfx::g_graphics_mgr.get_render_window();
+                std::pair<int, int> window_dimensions = prender_window->get_framebuffer_size();
+                //gfx::g_graphics_mgr.get_framebuffer_size(&m_curr_vport_width, &m_curr_vport_height);
+                m_curr_vport_width = window_dimensions.first;
+                m_curr_vport_height = window_dimensions.second;
 
                 if ((m_curr_vport_width != m_prev_vport_width) || (m_curr_vport_height != m_prev_vport_height)) {
                         m_curr_aspect_ratio = (float)m_curr_vport_width / (float)m_curr_vport_height;

--- a/engine/source/io/source/src/Input_manager.hpp
+++ b/engine/source/io/source/src/Input_manager.hpp
@@ -12,7 +12,7 @@ namespace io
          */
         class Input_manager {
         public:
-                void pool_events();
+                void pool_events(); // RENAME!!!!!!! IS POLL
                 // void init();
                 // void shut_down();
 

--- a/engine/source/src/engine.cpp
+++ b/engine/source/src/engine.cpp
@@ -8,6 +8,7 @@
 #include "Sprite_atlas_manager.hpp"
 #include "Input_abstraction_layer.hpp"
 
+#include "Glfw_manager.hpp"
 #include "Graphics_manager.hpp"
 #include "Physics_manager.hpp"
 #include "Game_object_manager.hpp"
@@ -20,20 +21,21 @@ static void error_callback(int error, const char * descr)
 	std::cerr << "GLFW ERROR: " << descr << std::endl;
 }
 
+// We need to Deal with error conditions!!!!!
 void engine_init(const uint32_t context_version_major, const uint32_t context_version_minor, Tile_map *ptile_map)
 {
 	//Shader_manager, texture_2d_manager and Sprite_atlas_manager dont need to be explicitly initialized
 
+        // initalize GLFW library
+        gfx::Glfw_manager::init(context_version_major, context_version_minor);
 	//initialize the  engine global managers
-	gfx::g_graphics_mgr.init(context_version_major, context_version_minor);
+	gfx::g_graphics_mgr.init(512, 480, "2D Game Project");
 	physics_2d::g_physics_mgr.init(ptile_map);
 	gom::g_game_object_mgr.init();
 	gom::g_projectile_mgr.init();
 
-    // ----------------------------------------New initialization code--------------------------------------------------------------------------------------------
-    gfx::g_graphics_mgr.set_error_callback(error_callback);
-    gfx::g_graphics_mgr.create_window(512, 480, "2D Game Project");
-    gfx::g_graphics_mgr.set_key_callback(io::Input_abstraction_layer::keyboard_callback);
+    gfx::Glfw_manager::set_error_callback(error_callback);
+    gfx::Glfw_manager::set_key_callback(gfx::g_graphics_mgr.get_render_window(), io::Input_abstraction_layer::keyboard_callback);
     
     Path resources_path("../resources", Path::FORWARD_SLASH);
     gom::g_level_mgr.load(resources_path, ptile_map);
@@ -46,6 +48,7 @@ void engine_shut_down()
 	gom::g_game_object_mgr.shut_down();
 	physics_2d::g_physics_mgr.shut_down();
 	gfx::g_graphics_mgr.shut_down();
+    gfx::Glfw_manager::terminate();
 
 	gfx::g_sprite_atlas_mgr.unload_all();
 	gfx::g_texture_2d_mgr.unload_all();

--- a/game/source/src/game.cpp
+++ b/game/source/src/game.cpp
@@ -49,6 +49,7 @@
 #include "Texture_2d_manager.hpp"
 #include "Sprite_atlas.hpp"
 #include "Sprite_atlas_manager.hpp"
+#include "Window.hpp"
 #include "Graphics_manager.hpp"
 
 //gom
@@ -157,7 +158,9 @@ int main(int argc, char *argv[])
         control_scheme.map_action_to_button(Abstract_game_actions_index::ATTACK_01, io::Abstract_keyboard_index::KEY_S);
 
         gom::g_level_mgr.get_camera().track(player_type_id);
-        while (!gfx::g_graphics_mgr.window_should_close()) {
+
+        gfx::Window * prender_window = gfx::g_graphics_mgr.get_render_window();
+        while (!prender_window->should_close()) {
                 gom::g_level_mgr.tick();
         }
         engine_shut_down();


### PR DESCRIPTION
### Description
The graphics manager is currently having to manage the glfw library, in addition of all the rendering tasks, this managing include: having to initialize/terminate the GLFW library, to manage the GLFWwindow struct, to work as a wrapper of the GLFLW library functions and, to handle the setting up of window related callbacks. To simply the graphics manager and keep it only responsible of rendering related tasks, this pull request adds the Window class to encapsulate the GLFWwindow struct, working as the graphics manager's render window and, the Glfw_manager class, as a manager/wrapper of the GLFW library.

[Ticket](https://app.hacknplan.com/p/68474/kanban?categoryId=0&boardId=198827&taskId=32&tabId=basicinfo)