### PR TITLE
NO-44 Implement SID Preprocessor Utility

### DIFF
--- a/engine/source/CMakeLists.txt
+++ b/engine/source/CMakeLists.txt
@@ -7,6 +7,9 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 #Using c++11
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
+include(cmake/preprocessor.cmake)
+include(cmake/util.cmake)
+
 FIND_PACKAGE(glfw3 3.2 REQUIRED)
 FIND_PACKAGE(OpenGL    REQUIRED)
 FIND_PACKAGE(GLEW      REQUIRED)

--- a/engine/source/CMakeLists.txt
+++ b/engine/source/CMakeLists.txt
@@ -46,6 +46,7 @@ FIND_PATH(GOM_INCLUDE_DIR NAMES game_object.hpp HINTS ${CMAKE_CURRENT_LIST_DIR}/
 
 ADD_SUBDIRECTORY(math/source)
 ADD_SUBDIRECTORY(utility/source)
+ADD_SUBDIRECTORY(sid_preprocessor/source)
 ADD_SUBDIRECTORY(mem/source)
 ADD_SUBDIRECTORY(rms/source)
 ADD_SUBDIRECTORY(io/source)

--- a/engine/source/cmake/preprocessor.cmake
+++ b/engine/source/cmake/preprocessor.cmake
@@ -1,0 +1,20 @@
+# run SID preprocessor tool on source files
+
+function(preprocess_source_files unprocessed_files preprocessed_files unprocessed_dir preprocessed_dir)
+	set(output_list "")
+	foreach(unprocessed_file ${unprocessed_files})
+		set(preprocessed_file "preprocessed_${unprocessed_file}")
+		add_custom_command(
+			OUTPUT ${preprocessed_file}
+			COMMAND sid_preprocessor "${unprocessed_dir}/${unprocessed_file}" 
+			                         "${preprocessed_dir}/${preprocessed_file}"
+			PRE_BUILD
+			DEPENDS "${unprocessed_dir}/${unprocessed_file}"
+			COMMENT "Running SID preprocessor on file ${unprocessed_file}...\
+		  generating ${preprocessed_file}"
+		)
+		message("Appending to ${output_list} ${preprocessed_dir}/${preprocessed_file}")
+		list(APPEND output_list "${preprocessed_dir}/${preprocessed_file}")
+	endforeach(unprocessed_file)
+	set(${preprocessed_files} "${output_list}" PARENT_SCOPE)
+endfunction()

--- a/engine/source/cmake/util.cmake
+++ b/engine/source/cmake/util.cmake
@@ -1,0 +1,8 @@
+function(prepend_string_to_list str values output_list)
+	set(aux_list "")
+	foreach(v ${values})
+		list(APPEND aux_list ${str}${v})
+		message("Appending ${str} to ${v} = ${str}${v}")
+	endforeach(v)
+	set(${output_list} "${aux_list}" PARENT_SCOPE)
+endfunction()

--- a/engine/source/sid_preprocessor/source/CMakeLists.txt
+++ b/engine/source/sid_preprocessor/source/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.6.4 FATAL_ERROR)
-project(sid_preprocessor VERSION 0.1 LANGUAGES CXX)
+cmake_minimum_required(VERSION 2.6.4)
+project(sid_preprocessor)
 
 set(include_files src/main.hpp)
 set(source_files src/main.cpp)

--- a/engine/source/sid_preprocessor/source/CMakeLists.txt
+++ b/engine/source/sid_preprocessor/source/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 2.6.4 FATAL_ERROR)
+project(sid_preprocessor VERSION 0.1 LANGUAGES CXX)
+
+set(include_files src/main.hpp)
+set(source_files src/main.cpp)
+
+add_executable(sid_preprocessor ${include_files} ${source_files})
+
+target_include_directories(sid_preprocessor PUBLIC 
+                           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+			   $<INSTALL_INTERFACE:include>
+			   PRIVATE src ${UTILITY_INCLUDE_DIR} )
+
+target_link_libraries(sid_preprocessor $<TARGET_OBJECTS:utility>)
+export(TARGETS sid_preprocessor FILE SidPreprocessorConfig.cmake)
+
+

--- a/engine/source/sid_preprocessor/source/CMakeLists.txt
+++ b/engine/source/sid_preprocessor/source/CMakeLists.txt
@@ -11,7 +11,7 @@ target_include_directories(sid_preprocessor PUBLIC
 			   $<INSTALL_INTERFACE:include>
 			   PRIVATE src ${UTILITY_INCLUDE_DIR} )
 
-target_link_libraries(sid_preprocessor $<TARGET_OBJECTS:utility>)
+target_link_libraries(sid_preprocessor ${GLFW3_LIBRARY} $<TARGET_OBJECTS:utility>)
 export(TARGETS sid_preprocessor FILE SidPreprocessorConfig.cmake)
 
 

--- a/engine/source/sid_preprocessor/source/src/main.cpp
+++ b/engine/source/sid_preprocessor/source/src/main.cpp
@@ -1,0 +1,111 @@
+#include "main.hpp"
+#include "crc32.hpp"
+#include <iomanip>
+#include <utility>
+#include <iostream>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <cstddef>
+
+/**
+ * Parse a line of code, replacing the single quoted string 
+ * in the macro SID('any-string'), by the corresponding hashed
+ * integer value, writing the parsed line on a output file
+*/
+void preprocess_line(std::string  line, std::fstream & output_file_stream)
+{
+        const std::string keyword("SID");
+        const std::string blank_characters(" \t\r");
+        const std::string alphanum("qwertyuiopasdfghjklzxcvbnmQWERTYUIOPASDFGHJKLZXCVBNM0123456789_");
+        std::size_t sid_pos = 0;
+        sid_pos = line.find(keyword, sid_pos);
+        while (sid_pos != std::string::npos) {
+                auto opening_paren_pos = line.find_first_not_of(blank_characters,
+                                                                sid_pos + keyword.length());
+                if (opening_paren_pos == std::string::npos || line[opening_paren_pos] != '(') {
+                        std::cerr << "Error: could not find open param" << std::endl;
+                        sid_pos = line.find(keyword, opening_paren_pos);
+                        continue;
+                }
+                auto first_quote_pos = line.find_first_not_of(blank_characters,
+                                                              opening_paren_pos + 1);
+                if (first_quote_pos == std::string::npos || line[first_quote_pos] != '\'') {
+                        sid_pos = first_quote_pos;
+                        std::cerr << "Error: could not find opening quote" << std::endl;
+                        sid_pos = line.find(keyword, first_quote_pos);
+                        continue;
+                }
+
+                auto second_quote_pos = line.find_first_not_of(alphanum, first_quote_pos + 1);
+                if (second_quote_pos == std::string::npos || line[second_quote_pos] != '\'' || 
+                    second_quote_pos == first_quote_pos + 1) {
+                        std::cerr << "ERROR: Missing closing quote" << std::endl;
+                        sid_pos = line.find(keyword, second_quote_pos);
+                        continue;
+                }
+                auto closing_paren_pos = line.find_first_not_of(blank_characters,
+                                                                second_quote_pos + 1);
+                // check if closing paren was found
+                if (closing_paren_pos == std::string::npos || line[closing_paren_pos] != ')') {
+                        std::cerr << "ERROR: Missing closing paren" << std::endl;
+                        sid_pos = line.find(keyword, closing_paren_pos);
+                        continue;
+                }
+
+                // if everthing is ok, get the string and apply the hash function
+                std::string str_to_hash = line.substr(first_quote_pos + 1,
+                                                      second_quote_pos - (first_quote_pos + 1));
+                std::uint32_t hashed_str = get_crc32(str_to_hash.c_str());
+
+                std::stringstream hex_str;
+                hex_str << "0x" << std::setfill('0') << std::setw(sizeof(std::uint32_t) * 2) 
+                        << std::hex << hashed_str;
+                
+                line.replace(opening_paren_pos + 1, closing_paren_pos - opening_paren_pos - 1,
+                             hex_str.str());
+                // recalculate the position of closing paren before searching for the next word
+                closing_paren_pos = line.find_first_of(')', opening_paren_pos);
+                sid_pos = line.find(keyword, closing_paren_pos + 1);
+        }
+
+        // write to output file
+        output_file_stream << line << '\n';
+}
+
+/**
+ * Get a file stream to both an input and an output
+ * source file and, iterate through the input file 
+ * running the sid parser on each line
+ */
+
+void sid_parser(const char * unprocessed_file_path, const char * preprocessed_file_path)
+{
+        std::fstream preprocessed_stream(preprocessed_file_path,
+                                         std::fstream::in | std::fstream::out | std::fstream::trunc);
+        std::ifstream unprocessed_file(unprocessed_file_path);
+        if (!preprocessed_stream.good()) {
+                // file does not exist create it first
+                std::ofstream outfile_stream(preprocessed_file_path);
+                outfile_stream.close();
+                preprocessed_stream.close();
+                preprocessed_stream.open(preprocessed_file_path,
+                                         std::fstream::in | std::fstream::out);
+        }
+        std::string line;
+        while (std::getline(unprocessed_file, line)) {
+                preprocess_line(line, preprocessed_stream);
+        }
+
+}
+
+int main(int argc, char * argv[])
+{
+        if (argc < 2) {
+                return -1;
+        }
+
+        const char *raw_file_path = argv[1];
+        const char *preprocessed_file_path = argv[2];
+        sid_parser(raw_file_path, preprocessed_file_path);
+}

--- a/engine/source/sid_preprocessor/source/src/main.hpp
+++ b/engine/source/sid_preprocessor/source/src/main.hpp
@@ -1,0 +1,10 @@
+#ifndef _SID_PREPROCESSOR_HPP
+#define _SID_PREPROCESSOR_HPP
+
+#include <string>
+#include <fstream>
+
+void preprocess_line(std::string  line, std::fstream & output_file_stream)
+void sid_parser(const char * unprocessed_file_path, const char * preprocessed_file_path);
+
+#endif // !_SID_PREPROCESSOR_HPP

--- a/engine/source/sid_preprocessor/source/src/main.hpp
+++ b/engine/source/sid_preprocessor/source/src/main.hpp
@@ -4,7 +4,7 @@
 #include <string>
 #include <fstream>
 
-void preprocess_line(std::string  line, std::fstream & output_file_stream)
+void preprocess_line(std::string  line, std::fstream & output_file_stream);
 void sid_parser(const char * unprocessed_file_path, const char * preprocessed_file_path);
 
 #endif // !_SID_PREPROCESSOR_HPP

--- a/engine/source/utility/source/src/crc32.hpp
+++ b/engine/source/utility/source/src/crc32.hpp
@@ -1,6 +1,8 @@
 #ifndef _CRC32_HPP
 #define _CRC32_HPP
 
+#define SID(string) string
+
 #include <cstdint>
 
 extern std::uint32_t crc_table[256];


### PR DESCRIPTION
### Description
 This PR implements the SID preprocessor Utility. This preprocessor, searches a source file for 
the `SID('any-string')` macro, and replaces it with the corresponding hashed strinag value, such as `0Xfa346543`. With this utility, we can generate new preprocessed source files, that have all occurrences of the SID macro, substituted by the corresponding hashed value. This way, we don't have the overhead of hashing the strings in real time and, can use the SID macro anywhere a constant expression value can be used.  So now we can have a build step, that runs the SID preprocessor utility, generating the preprocessed source files, before compiling and generating the executable.

[Ticket](https://app.hacknplan.com/p/68474/kanban?categoryId=0&boardId=234155&taskId=44&tabId=basicinfo)