### PR TITLE
NO-49 Allow the creation of Game_objects without a respective Creator class

### DIFF
--- a/engine/source/gom/source/src/Actor.cpp
+++ b/engine/source/gom/source/src/Actor.cpp
@@ -18,16 +18,18 @@
 
 #include "runtime_memory_allocator.hpp"
 
+#include <cstddef>
+
 
 //TAKE OUT MAGIC NUMBER 16 ON SPRITE CONSTRUCTOR
 //Actor::Actor(const cgm::vec3 & pos, const cgm::mat4 & orientation, const std::string & texture_file, State *pstate, const AABB_2d & aabb, const cgm::vec2 & velocity, bool facing_left)
 //	: Renderable_game_object(pos, orientation, texture_file), m_pstate(pstate), m_aabb(aabb), m_velocity(velocity), m_facing_left(facing_left) {}
 namespace gom {
 
-	Actor::Actor(const game_object_id unique_id, const uint16_t handle_index,
-                 atlas_n_layer & sprite_data, physics_2d::Body_2d_def *pbody_def,
-                 const gfx::Animator_controller *pcontroller, bool facing_left) : 
-                   Game_object(unique_id, handle_index, pbody_def->m_position), m_pstate(nullptr), m_velocity(pbody_def->m_linear_velocity), m_facing_left(facing_left)
+	Actor::Actor(std::size_t object_sz, atlas_n_layer & sprite_data,
+                 physics_2d::Body_2d_def *pbody_def, const gfx::Animator_controller *pcontroller,
+                 bool facing_left) : 
+                   Game_object(object_sz, pbody_def->m_position), m_pstate(nullptr), m_velocity(pbody_def->m_linear_velocity), m_facing_left(facing_left)
 	{
 		//create sprite component
 		void *pmem = mem::allocate(sizeof(gfx::Sprite));

--- a/engine/source/gom/source/src/Actor.hpp
+++ b/engine/source/gom/source/src/Actor.hpp
@@ -3,6 +3,7 @@
 
 
 #include <utility>
+#include <cstddef>
 #include "vec2.hpp"
 #include "Game_object.hpp"
 
@@ -19,8 +20,7 @@ namespace gom {
 	public:
 		typedef std::pair < const gfx::Sprite_atlas*, uint8_t> atlas_n_layer;
 
-		Actor(const game_object_id unique_id, const uint16_t handle_index,
-              atlas_n_layer & sprite_data, physics_2d::Body_2d_def *pbody_def,
+		Actor(std::size_t object_sz, atlas_n_layer & sprite_data, physics_2d::Body_2d_def *pbody_def,
               const gfx::Animator_controller *pcontroller, bool facing_left = true);
 
 		virtual ~Actor();

--- a/engine/source/gom/source/src/Creator.hpp
+++ b/engine/source/gom/source/src/Creator.hpp
@@ -15,22 +15,19 @@ namespace physics_2d {struct Body_2d_def; }
 namespace gom {
 	class Creator {
 	public:
-		Creator(const std::size_t sz) : m_pbody_def(nullptr), m_size(sz) {}
+		Creator() : m_pbody_def(nullptr) {}
 		virtual ~Creator();
 
-		virtual Game_object *create(void * pmem, const uint32_t unique_id, const uint16_t handle_index, const math::vec3 & wld_pos) = 0;
+		virtual Game_object *create(const math::vec3 & wld_pos) = 0;
 		
 		void		 set_obj_type(const uint32_t type) { m_obj_type = type; }
 		uint32_t     get_obj_type() const { return m_obj_type; }
         void         set_obj_tag(const uint32_t tag) { m_obj_tag = tag; }
         uint32_t     get_obj_tag() const { return m_obj_tag; }
-		std::size_t  get_size()    const { return m_size; }
 	protected:
 		physics_2d::Body_2d_def *m_pbody_def; // used to create Body_2d for game objects that need physics simulation
 		uint32_t				 m_obj_type;
         uint32_t                 m_obj_tag;
-	private:
-		std::size_t m_size; // size in bytes
 	};
 }
 #endif // !_CREATOR_HPP

--- a/engine/source/gom/source/src/Game_object.cpp
+++ b/engine/source/gom/source/src/Game_object.cpp
@@ -33,6 +33,10 @@ namespace gom {
             m_transform = math::Transform(position);
     }
 
+    void Game_object::destroy()
+    {
+            gom::g_game_object_mgr.request_destruction(Game_object_handle(*this));
+    }
 
 	Game_object::~Game_object()
 	{

--- a/engine/source/gom/source/src/Game_object.cpp
+++ b/engine/source/gom/source/src/Game_object.cpp
@@ -5,24 +5,34 @@
 #include "Body_2d.hpp"
 #include "Animator_controller.hpp"
 #include "Event.hpp"
+#include "Game_object_handle.hpp"
+#include "Game_object_manager.hpp"
 
 #include "runtime_memory_allocator.hpp"
 #include "World.hpp"
 #include "Physics_manager.hpp"
 
 namespace gom {
-	Game_object::Game_object(const game_object_id unique_id, const uint16_t handle_index) :
-		m_unique_id(unique_id), m_handle_index(handle_index), m_is_active(true), 
-        m_psprite(nullptr), m_panimator_controller(nullptr), m_pbody_2d(nullptr) {}
+	Game_object::Game_object(std::size_t alloc_sz) : 
+        m_is_active(true), m_psprite(nullptr), m_panimator_controller(nullptr), m_pbody_2d(nullptr)
+    {
+            Game_object_handle handle = g_game_object_mgr.register_game_object(this, alloc_sz);
+            m_unique_id = handle.get_unique_id();
+            m_handle_index = handle.get_index();
+    }
 
-	Game_object::Game_object(const game_object_id unique_id, const uint16_t handle_index, const math::Transform & transform) 
-		: m_unique_id(unique_id), m_handle_index(handle_index), m_is_active(true), 
-          m_transform(transform), m_psprite(nullptr), m_panimator_controller(nullptr),
-          m_pbody_2d(nullptr) {}
+    Game_object::Game_object(std::size_t alloc_sz, const math::Transform & transform) : 
+            Game_object(alloc_sz) 
+    {
+            m_transform = transform;
+    }
 
-	Game_object::Game_object(const game_object_id unique_id, const uint16_t handle_index, const math::vec3 & position)
-		: m_unique_id(unique_id), m_handle_index(handle_index), m_is_active(true), m_transform(position),
-          m_psprite(nullptr), m_panimator_controller(nullptr), m_pbody_2d(nullptr) {}
+	Game_object::Game_object(std::size_t alloc_sz, const math::vec3 & position)
+		: Game_object(alloc_sz) 
+    {
+            m_transform = math::Transform(position);
+    }
+
 
 	Game_object::~Game_object()
 	{

--- a/engine/source/gom/source/src/Game_object.hpp
+++ b/engine/source/gom/source/src/Game_object.hpp
@@ -15,10 +15,12 @@
 
 namespace gfx { class Sprite; class Animator_controller; }
 namespace physics_2d { class Body_2d; }
+namespace gom { class Game_object_manager; }
 class Event;
-namespace gom {
 
+namespace gom {
         class Game_object {
+                friend Game_object_manager;
         public:
                 typedef uint32_t game_object_id;
 

--- a/engine/source/gom/source/src/Game_object.hpp
+++ b/engine/source/gom/source/src/Game_object.hpp
@@ -31,6 +31,8 @@ namespace gom {
                 Game_object(Game_object && game_object) = delete;
                 Game_object & operator=(const Game_object & rhs) = delete;
 
+                void                  destroy();
+
                 game_object_id        get_unique_id() const;
                 uint16_t			  get_handle_index() const;
                 bool				  is_active() const { return m_is_active; }

--- a/engine/source/gom/source/src/Game_object.hpp
+++ b/engine/source/gom/source/src/Game_object.hpp
@@ -11,7 +11,6 @@
  * add new ones if necessary.
  */
  //TODO: CHANGE THE ORIENTATION TO BE A 3X3 MATRIX!
- //TODO: MANAGE COPY CONTROLL!!!!
 
 namespace gfx { class Sprite; class Animator_controller; }
 namespace physics_2d { class Body_2d; }
@@ -30,7 +29,6 @@ namespace gom {
 
                 Game_object(const game_object_id unique_id, const uint16_t handle_index,
                             const math::vec3 & position);
-                //MISSING COPY CONTROLL!!!!!!!!
                 virtual ~Game_object();
                 Game_object(const Game_object & game_object) = delete;
                 Game_object(Game_object && game_object) = delete;

--- a/engine/source/gom/source/src/Game_object.hpp
+++ b/engine/source/gom/source/src/Game_object.hpp
@@ -23,13 +23,10 @@ namespace gom {
         public:
                 typedef uint32_t game_object_id;
 
-                Game_object(const game_object_id unique_id, const uint16_t handle_index);
-                Game_object(const game_object_id unique_id, const uint16_t handle_index,
-                            const math::Transform & transform);
+                Game_object(std::size_t alloc_sz);
+                Game_object(std::size_t alloc_sz, const math::Transform & transform);
+                Game_object(std::size_t alloc_sz, const math::vec3 & position);
 
-                Game_object(const game_object_id unique_id, const uint16_t handle_index,
-                            const math::vec3 & position);
-                virtual ~Game_object();
                 Game_object(const Game_object & game_object) = delete;
                 Game_object(Game_object && game_object) = delete;
                 Game_object & operator=(const Game_object & rhs) = delete;

--- a/engine/source/gom/source/src/Game_object.hpp
+++ b/engine/source/gom/source/src/Game_object.hpp
@@ -32,6 +32,9 @@ namespace gom {
                             const math::vec3 & position);
                 //MISSING COPY CONTROLL!!!!!!!!
                 virtual ~Game_object();
+                Game_object(const Game_object & game_object) = delete;
+                Game_object(Game_object && game_object) = delete;
+                Game_object & operator=(const Game_object & rhs) = delete;
 
                 game_object_id        get_unique_id() const;
                 uint16_t			  get_handle_index() const;

--- a/engine/source/gom/source/src/Game_object.hpp
+++ b/engine/source/gom/source/src/Game_object.hpp
@@ -53,6 +53,7 @@ namespace gom {
                 virtual void update(const float dt) = 0;
                 virtual void on_event(Event & event);
         protected:
+                virtual ~Game_object();
                 math::Transform				 m_transform;//
                 gfx::Sprite					*m_psprite;// 4 bytes
                 gfx::Animator_controller	*m_panimator_controller; // 4 bytes

--- a/engine/source/gom/source/src/Game_object_handle.hpp
+++ b/engine/source/gom/source/src/Game_object_handle.hpp
@@ -16,6 +16,8 @@ namespace gom {
 		explicit Game_object_handle(const Game_object & game_object);
 
         void bind(const Game_object & game_object);
+        game_object_id          get_unique_id() const { return m_unique_id; }
+        uint16_t                get_index() const { return m_handle_index; }
 	private:
 		game_object_id m_unique_id;
 		uint16_t	   m_handle_index;

--- a/engine/source/gom/source/src/Game_object_manager.cpp
+++ b/engine/source/gom/source/src/Game_object_manager.cpp
@@ -263,8 +263,8 @@ namespace gom
 
         Game_object_manager::vgame_object_handles Game_object_manager::find_game_objects_with_type(uint32_t type)
         {
-                vgame_object_handles            handles;
-                vpgame_objects::iterator        it = m_game_objects.begin();
+                vgame_object_handles  handles;
+                vpgame_objects::iterator  it = m_game_objects.begin();
                 for (; it != m_game_objects.end(); ++it) {
                         if (type == (*it)->get_type()) {
                                 handles.push_back(Game_object_handle(*(*it)));

--- a/engine/source/gom/source/src/Game_object_manager.hpp
+++ b/engine/source/gom/source/src/Game_object_manager.hpp
@@ -4,6 +4,7 @@
 #include <vector>
 #include <stdint.h>
 
+#include "Game_object.hpp"
 
 /* Game_object_manager: class responsable to instantiate and store all the game objects
    in the world. All the objects are stored in a handle table and should only be accessed by
@@ -12,7 +13,7 @@
    is able to create a Game_object of the specific type.
  */
 namespace math { struct vec3; }
-namespace gom { class Game_object; class Creator; class Game_object_handle; class Camera_2d; }
+namespace gom {class Creator; class Game_object_handle; class Camera_2d; }
 
 namespace gom {
 
@@ -24,6 +25,7 @@ namespace gom {
 
 
         class  Game_object_manager final {
+                friend Game_object::Game_object(std::size_t);
         public:
                 typedef uint32_t	                           	type_id;
                 typedef std::map<type_id, Creator*>	           	creator_map;

--- a/engine/source/gom/source/src/Game_object_manager.hpp
+++ b/engine/source/gom/source/src/Game_object_manager.hpp
@@ -32,15 +32,18 @@ namespace gom {
                 typedef std::vector<Game_object*>		        vpgame_objects;
                 typedef std::vector<Game_object_handle>         vgame_object_handles;
 
-                //constructor and destructor
                 Game_object_manager() = default;
                 ~Game_object_manager() = default;
 
                 void				        init();
                 void				        shut_down();
 
-                bool				        register_creator(const type_id obj_type, Creator *pcreator, const uint32_t obj_tag = -1);
-                Game_object_handle          instantiate(const type_id obj_type, const math::vec3 & wld_pos);
+                bool				        register_creator(const type_id obj_type, Creator *pcreator,
+                                                             const uint32_t obj_tag = -1);
+
+                Game_object_handle          instantiate(const type_id obj_type,
+                                                        const math::vec3 & wld_pos);
+
                 void				        request_destruction(const Game_object_handle & handle);
                 void				        update_game_objects(const float dt);
                 void                        reset();

--- a/engine/source/gom/source/src/Game_object_manager.hpp
+++ b/engine/source/gom/source/src/Game_object_manager.hpp
@@ -54,6 +54,9 @@ namespace gom {
                 void                        set_main_camera(Camera_2d * pmain_camera);
                 Camera_2d *                 get_main_camera();
         private:
+                Game_object_handle          register_game_object(Game_object *pgame_object,
+                                                                 std::size_t object_sz);
+
                 void				  destroy_requested_game_objects();
 
                 static const uint16_t      m_MAX_GAME_OBJECTS = 1024;

--- a/engine/source/gom/source/src/Projectile.cpp
+++ b/engine/source/gom/source/src/Projectile.cpp
@@ -20,14 +20,14 @@
 #include "Game_object_manager.hpp"
 #include "runtime_memory_allocator.hpp"
 
+#include <cstddef>
 #include <iostream>
 
 namespace gom {
-	Projectile::Projectile(const game_object_id unique_id, const uint16_t handle_index,
-                           const math::vec3 & pos, atlas_n_layer & sprite_data,
+	Projectile::Projectile(std::size_t object_sz, const math::vec3 & pos, atlas_n_layer & sprite_data,
                            physics_2d::Body_2d_def *pbody_def,
                            const gfx::Animator_controller *pcontroller) :
-		gom::Game_object(unique_id, handle_index, pos), m_hit(false), m_damage(20)
+		gom::Game_object(object_sz, pos), m_hit(false), m_damage(20)
 	{
 		//create the sprite component
 		void *pmem = mem::allocate(sizeof(gfx::Sprite));

--- a/engine/source/gom/source/src/Projectile.hpp
+++ b/engine/source/gom/source/src/Projectile.hpp
@@ -2,6 +2,7 @@
 #define _PROJECTILE_HPP
 #include "Game_object.hpp"
 #include <utility>
+#include <cstddef>
 
 namespace gfx { class Sprite_atlas; class Animator_controller; }
 namespace physics_2d { struct Body_2d_def; }
@@ -12,8 +13,7 @@ namespace gom {
 	class Projectile : public Game_object {
 	public:
 		typedef std::pair <const gfx::Sprite_atlas*, uint8_t> atlas_n_layer;
-		Projectile(const game_object_id unique_id, const uint16_t handle_index,
-                   const math::vec3 & pos, atlas_n_layer & sprite_data,
+		Projectile(std::size_t object_sz, const math::vec3 & pos, atlas_n_layer & sprite_data,
                    physics_2d::Body_2d_def *pbody_def, const gfx::Animator_controller *pcontroller);
 
 		void set_direction(const math::vec2 & dir);

--- a/game/source/src/Hover_robot.cpp
+++ b/game/source/src/Hover_robot.cpp
@@ -22,10 +22,10 @@
 
 #include <cstdint>
 
-Hover_robot::Hover_robot(const game_object_id unique_id, const uint16_t handle_index,
-                         atlas_n_layer & sprite_data, physics_2d::Body_2d_def *pbody_def, 
+Hover_robot::Hover_robot(std::size_t object_sz, atlas_n_layer & sprite_data,
+                         physics_2d::Body_2d_def *pbody_def,
                          const gfx::Animator_controller *pcontroller, bool facing_left) : 
-                           Actor(unique_id, handle_index, sprite_data, pbody_def, pcontroller, facing_left) 
+                           Actor(object_sz, sprite_data, pbody_def, pcontroller, facing_left) 
 {
         m_health = 100;
         m_damage = 25;

--- a/game/source/src/Hover_robot.hpp
+++ b/game/source/src/Hover_robot.hpp
@@ -3,6 +3,7 @@
 
 #include "Actor.hpp"
 #include <stdint.h>
+#include <cstddef>
 
 namespace gfx { class Sprite; class Animator_controller; }
 namespace physics_2d { class Body_2d; struct Body_2d_def; }
@@ -10,9 +11,9 @@ class Event;
 
 class Hover_robot final : public gom::Actor{
 public:
-	Hover_robot(const game_object_id unique_id, const uint16_t handle_index,
-                atlas_n_layer & sprite_data, physics_2d::Body_2d_def *pbody_def, 
-                const gfx::Animator_controller *pcontroller, bool facing_left = true);
+	Hover_robot(std::size_t object_sz, atlas_n_layer & sprite_data,
+                physics_2d::Body_2d_def *pbody_def, const gfx::Animator_controller *pcontroller,
+                bool facing_left = true);
 
 	void update(const float dt) override;
     void on_event(Event & event) override;

--- a/game/source/src/Hover_robot_creator.cpp
+++ b/game/source/src/Hover_robot_creator.cpp
@@ -22,8 +22,9 @@
 
 #include "runtime_memory_allocator.hpp"
 
-Hover_robot_creator::Hover_robot_creator(const string_id atlas_res_id, const string_id anim_controll_id) 
-	: gom::Creator(sizeof(Hover_robot)), m_atlas_res_id(atlas_res_id), m_anim_controller_id(anim_controll_id)
+Hover_robot_creator::Hover_robot_creator(const string_id atlas_res_id,
+                                         const string_id anim_controll_id) : 
+        gom::Creator(), m_atlas_res_id(atlas_res_id), m_anim_controller_id(anim_controll_id)
 {
 	void *pmem = mem::allocate(sizeof(physics_2d::Body_2d_def));
 	if (pmem) {
@@ -70,7 +71,7 @@ Hover_robot_creator::~Hover_robot_creator()
 	mem::free(static_cast<void*>(m_panim_controller), sizeof(gfx::Animator_controller));
 }
 
-gom::Game_object * Hover_robot_creator::create(void * pmem, const uint32_t unique_id, const uint16_t handle_index, const math::vec3 & wld_pos) 
+gom::Game_object * Hover_robot_creator::create(const math::vec3 & wld_pos) 
 {
 	// get the data for creating the sprite componenent
 	gfx::Sprite_atlas *patlas = static_cast<gfx::Sprite_atlas*>(gfx::g_sprite_atlas_mgr.get_by_id(m_atlas_res_id));
@@ -81,14 +82,15 @@ gom::Game_object * Hover_robot_creator::create(void * pmem, const uint32_t uniqu
 	m_pbody_def->m_aabb.p_max += tr;
 	m_pbody_def->m_aabb.p_min += tr;
 
-	//create a collider_def
 	physics_2d::Collider_2d_def coll_def;
 	coll_def.m_aabb = m_pbody_def->m_aabb;
 	coll_def.m_is_trigger = true;
 
 
 
-	gom::Game_object *pgame_object = static_cast<gom::Game_object*>(new (pmem) Hover_robot(unique_id, handle_index, sprite_data, m_pbody_def, m_panim_controller));
+    std::size_t object_sz = sizeof(Hover_robot);
+    void *pmem = mem::allocate(object_sz);
+	gom::Game_object *pgame_object = static_cast<gom::Game_object*>(new (pmem) Hover_robot(object_sz, sprite_data, m_pbody_def, m_panim_controller));
 	pgame_object->get_body_2d_component()->create_collider_2d(coll_def);
 	pgame_object->set_type(m_obj_type);
     pgame_object->set_tag(m_obj_tag);

--- a/game/source/src/Hover_robot_creator.hpp
+++ b/game/source/src/Hover_robot_creator.hpp
@@ -12,7 +12,7 @@ namespace gfx { class Animator_controller; }
 class Hover_robot_creator : public gom::Creator {
 public:
 	Hover_robot_creator(const string_id atlas_res_id, const string_id anim_controll_id);
-	gom::Game_object * create(void * pmem, const uint32_t unique_id, const uint16_t handle_index, const math::vec3 & wld_pos) override;
+	gom::Game_object * create(const math::vec3 & wld_pos) override;
 
 	~Hover_robot_creator() override;
 private:

--- a/game/source/src/Player.cpp
+++ b/game/source/src/Player.cpp
@@ -21,10 +21,10 @@
 #include <iostream>
 
 
-Player::Player(const game_object_id unique_id, const uint16_t handle_index,
-               atlas_n_layer & sprite_data, physics_2d::Body_2d_def *pbody_def,
-               const gfx::Animator_controller *pcontroller, bool facing_left) :
-	             Actor(unique_id, handle_index, sprite_data, pbody_def, pcontroller, facing_left)
+Player::Player(std::size_t object_sz, atlas_n_layer & sprite_data,
+               physics_2d::Body_2d_def *pbody_def, const gfx::Animator_controller *pcontroller,
+               bool facing_left) :
+	             Actor(object_sz, sprite_data, pbody_def, pcontroller, facing_left)
 {
 	void *pmem = mem::allocate(sizeof(Player_idle_state));
 	m_pstate = static_cast<gom::Gameplay_state*>(new (pmem) Player_idle_state());

--- a/game/source/src/Player.hpp
+++ b/game/source/src/Player.hpp
@@ -1,6 +1,7 @@
 #ifndef _PLAYER_HPP
 #define _PLAYER_HPP
 #include "Actor.hpp"
+#include <cstddef>
 
 namespace math { struct vec2; struct vec3; class mat4; }
 namespace physics_2d { struct AABB_2d; class Body_2d; class World; }
@@ -9,9 +10,9 @@ class Event;
 
 class Player final : public gom::Actor {
 public:
-        Player(const game_object_id unique_id, const uint16_t handle_index,
-               atlas_n_layer & sprite_data, physics_2d::Body_2d_def *pbody_def, 
-               const gfx::Animator_controller *pcontroller, bool facing_left = true);
+        Player(std::size_t object_sz, atlas_n_layer & sprite_data,
+               physics_2d::Body_2d_def *pbody_def, const gfx::Animator_controller *pcontroller,
+               bool facing_left = true);
 
         void            handle_input();
         void            update(const float dt) override;

--- a/game/source/src/Player_creator.cpp
+++ b/game/source/src/Player_creator.cpp
@@ -21,7 +21,7 @@
 #include <stdint.h>
 
 Player_creator::Player_creator(const string_id atlas_id, const string_id anim_controller_id) :
-	gom::Creator(sizeof(Player)), m_atlas_res_id(atlas_id), m_anim_controller_id(anim_controller_id)
+	gom::Creator(), m_atlas_res_id(atlas_id), m_anim_controller_id(anim_controller_id)
 {
 	//set the body_def to be able to create body_2d objects for the game object
 	void  *pmem = mem::allocate(sizeof(physics_2d::Body_2d_def));
@@ -45,24 +45,27 @@ Player_creator::Player_creator(const string_id atlas_id, const string_id anim_co
 	create_anim_controller();
 }
 
-gom::Game_object *Player_creator::create(void *pmem, const uint32_t unique_id, const uint16_t handle_index, const math::vec3 & wld_pos)
+gom::Game_object *Player_creator::create(const math::vec3 & wld_pos)
 {
 	//get the sprite_atlas resource 
 	gfx::Sprite_atlas *patlas = static_cast<gfx::Sprite_atlas*>(gfx::g_sprite_atlas_mgr.get_by_id(m_atlas_res_id));
 	gom::Actor::atlas_n_layer sprite_data(patlas, 1);
 
-    math::vec2	tr = math::vec2(wld_pos.x - m_pbody_def->m_position.x, wld_pos.y - m_pbody_def->m_position.y);
+    math::vec2	tr = math::vec2(wld_pos.x - m_pbody_def->m_position.x,
+                                wld_pos.y - m_pbody_def->m_position.y);
 	m_pbody_def->m_position += tr;
 	m_pbody_def->m_aabb.p_max += tr;
 	m_pbody_def->m_aabb.p_min += tr;
 	
-	//create a collider_def
 	physics_2d::Collider_2d_def coll_def;
 	coll_def.m_aabb = m_pbody_def->m_aabb;
 	coll_def.m_is_trigger = false;
 
-	//call the player's constructor
-	gom::Game_object *pgame_object = static_cast<gom::Game_object*>(new (pmem) Player(unique_id, handle_index, sprite_data, m_pbody_def, m_panim_controller));
+    std::size_t obj_sz = sizeof(Player);
+    void *pmem = mem::allocate(obj_sz);
+    gom::Game_object *pgame_object = static_cast<gom::Game_object*>(new (pmem) Player(obj_sz, sprite_data, m_pbody_def, m_panim_controller));
+
+
 	pgame_object->get_body_2d_component()->create_collider_2d(coll_def);
 	pgame_object->set_type(m_obj_type);
     pgame_object->set_tag(m_obj_tag);

--- a/game/source/src/Player_creator.hpp
+++ b/game/source/src/Player_creator.hpp
@@ -13,7 +13,7 @@ namespace math { struct vec3; }
 class Player_creator : public gom::Creator {
 public:
 	Player_creator(const string_id atlas_id, const string_id anim_controller_id);
-	gom::Game_object *create(void * pmem, const uint32_t unique_id, const uint16_t handle_index, const math::vec3 & wld_pos) override;
+	gom::Game_object *create(const math::vec3 & wld_pos) override;
 
 	~Player_creator() override;
 private:

--- a/game/source/src/Projectile_creator.cpp
+++ b/game/source/src/Projectile_creator.cpp
@@ -21,8 +21,10 @@
 
 #include <utility>
 
-Projectile_creator::Projectile_creator(const string_id atlas_id, const physics_2d::Body_2d_def & body_def ,const gfx::Animator_controller *panim_controller) : 
-	gom::Creator(sizeof(gom::Projectile)), m_atlas_res_id(atlas_id)
+Projectile_creator::Projectile_creator(const string_id atlas_id,
+                                       const physics_2d::Body_2d_def & body_def,
+                                       const gfx::Animator_controller *panim_controller) : 
+        gom::Creator(), m_atlas_res_id(atlas_id)
 {
 	//create body_2d_def
 	void *pmem = mem::allocate(sizeof(physics_2d::Body_2d_def));
@@ -35,7 +37,7 @@ Projectile_creator::Projectile_creator(const string_id atlas_id, const physics_2
 	m_pcontroller = static_cast<gfx::Animator_controller*>(new (pmem) gfx::Animator_controller(*panim_controller));
 }
 
-gom::Game_object *Projectile_creator::create(void * pmem, const uint32_t unique_id, const uint16_t handle_index, const math::vec3 & wld_pos) 
+gom::Game_object *Projectile_creator::create(const math::vec3 & wld_pos) 
 {
 	//get the data to create sprite component
 	gfx::Sprite_atlas *patlas = static_cast<gfx::Sprite_atlas*>(gfx::g_sprite_atlas_mgr.get_by_id(m_atlas_res_id));
@@ -51,7 +53,9 @@ gom::Game_object *Projectile_creator::create(void * pmem, const uint32_t unique_
 	coll_def.m_aabb = m_pbody_def->m_aabb;
 	coll_def.m_is_trigger = true;
 
-	gom::Game_object *pgame_object = static_cast<gom::Game_object*>(new (pmem) gom::Projectile(unique_id, handle_index, wld_pos, data, m_pbody_def, m_pcontroller));
+    std::size_t object_sz = sizeof(gom::Projectile);
+    void *pmem = mem::allocate(object_sz);
+    gom::Game_object *pgame_object = static_cast<gom::Game_object*>(new (pmem) gom::Projectile(object_sz, wld_pos, data, m_pbody_def, m_pcontroller));
 	pgame_object->get_body_2d_component()->create_collider_2d(coll_def);
 	pgame_object->set_type(m_obj_type);
     pgame_object->set_tag(m_obj_tag);

--- a/game/source/src/Projectile_creator.hpp
+++ b/game/source/src/Projectile_creator.hpp
@@ -12,7 +12,7 @@ namespace physics_2d { struct Body_2d_def; }
 class Projectile_creator : public gom::Creator {
 public:
 	Projectile_creator(const string_id atlas_id, const physics_2d::Body_2d_def & body_def, const gfx::Animator_controller *panim_controller);
-	gom::Game_object *create(void * pmem, const uint32_t unique_id, const uint16_t handle_index, const math::vec3 & wld_pos) override;
+	gom::Game_object *create(const math::vec3 & wld_pos) override;
 
 	~Projectile_creator() override;
 private:


### PR DESCRIPTION
### Description
  This PR, regarding NO-49, refactors the Game_object and the Game_object_manager class, to allow the creation of Game_object instances, without the need of a respective Creator class. The main change to Game_object class, is that now it asks the Game_object_manager for if's guid and handle index when executing it's constructor, removing the need of having a creator pass those values to its constructor. This gives us more flexibility, without removing the feature of using creators to instantiate specific Game_object types.

[Jira's ticket](https://app.hacknplan.com/p/68474/kanban?categoryId=0&boardId=234155&taskId=49&tabId=basicinfo)