### PR TITLE
No-51 Implement screen scaling

### DIFF
--- a/engine/source/gfx/source/src/Glfw_manager.cpp
+++ b/engine/source/gfx/source/src/Glfw_manager.cpp
@@ -21,9 +21,10 @@ namespace gfx
                 glfwWindowHint(hint, value);
         }
 
-        Window * Glfw_manager::create_window(int width, int height, const char * ptitle)
+        Window * Glfw_manager::create_window(int width, int height, float viewport_scale,
+                                             const char * ptitle)
         {
-                return new Window(width, height, ptitle);
+                return new Window(width, height, viewport_scale, ptitle);
         }
 
         void Glfw_manager::swap_interval(int interval)

--- a/engine/source/gfx/source/src/Glfw_manager.hpp
+++ b/engine/source/gfx/source/src/Glfw_manager.hpp
@@ -16,7 +16,8 @@ namespace gfx
                 static void          init(int context_version_major, int context_version_minor);
                 static void          terminate();
                 static void          window_hint(int hint, int value);
-                static Window *      create_window(int width, int height, const char *ptitle);
+                static Window *      create_window(int width, int height, float viewport_scale,
+                                                   const char *ptitle);
                 static void          swap_interval(int interval);
                 static void          make_context_current(Window * pwindow);
                 static void          poll_events();

--- a/engine/source/gfx/source/src/Graphics_manager.cpp
+++ b/engine/source/gfx/source/src/Graphics_manager.cpp
@@ -32,7 +32,8 @@ gfx::Graphics_manager gfx::g_graphics_mgr;
 
 gfx::Graphics_manager::Graphics_manager() : m_is_initialized(false) {}
 
-bool gfx::Graphics_manager::init(int window_width, int window_height, const char * ptitle, float pixels_per_unit)
+bool gfx::Graphics_manager::init(int window_width, int window_height, float viewport_scale,
+                                 const char * ptitle, float pixels_per_unit)
 {
 	m_pixels_per_unit = pixels_per_unit;
 	m_tiles_per_screen_width = 16;
@@ -46,7 +47,8 @@ bool gfx::Graphics_manager::init(int window_width, int window_height, const char
 	m_batches.reserve(3);
 
     // Create render window
-    m_prender_window = Glfw_manager::create_window(window_width, window_height, ptitle);
+    m_prender_window = Glfw_manager::create_window(window_width, window_height, viewport_scale,
+                                                   ptitle);
 
     if (!m_prender_window->is_initialized()) {
             shut_down();

--- a/engine/source/gfx/source/src/Graphics_manager.hpp
+++ b/engine/source/gfx/source/src/Graphics_manager.hpp
@@ -33,7 +33,8 @@ namespace gfx {
             Graphics_manager();
             ~Graphics_manager() = default;
 		//initialization functions
-            bool		init(int window_width, int window_height, const char * ptitle, float pixels_per_unit = 16.0f);
+            bool		init(int window_width, int window_height, float viewport_scale,
+                             const char * ptitle, float pixels_per_unit);
             Window  *   get_render_window();
 		//bool        create_window(const std::int32_t width, const std::int32_t height, const char *ptitle);
 		

--- a/engine/source/gfx/source/src/Window.cpp
+++ b/engine/source/gfx/source/src/Window.cpp
@@ -1,5 +1,6 @@
 #include "Window.hpp"
 #include <GLFW/glfw3.h>
+#include "Graphics_manager.hpp"
 
 #include <utility>
 namespace gfx
@@ -20,6 +21,31 @@ namespace gfx
                 int width, height;
                 glfwGetFramebufferSize(m_pglfw_window, &width, &height);
                 return std::make_pair(width, height);
+        }
+
+        void Window::update_viewport()
+        {
+                std::pair<int, int> screen_dimensions = get_framebuffer_size();
+                if (screen_dimensions.first == m_width && screen_dimensions.second == m_height) {
+                        return;
+                }
+
+                int scaled_viewport_width = screen_dimensions.first;
+                int scaled_viewport_height = scaled_viewport_width / m_virtual_aspect_ratio;
+                if (scaled_viewport_height > screen_dimensions.second) {
+                        scaled_viewport_height = screen_dimensions.second;
+                        scaled_viewport_width = scaled_viewport_height * m_virtual_aspect_ratio;
+                }
+
+                int x = (screen_dimensions.first / 2.0f) - (scaled_viewport_width / 2.0f);
+                int y = (screen_dimensions.second / 2.0f) - (scaled_viewport_height / 2.0f);
+
+                gfx::g_graphics_mgr.set_viewport(x, y, scaled_viewport_width,
+                                                 scaled_viewport_height);
+
+                m_width = screen_dimensions.first;
+                m_height = screen_dimensions.second;
+                m_scale = scaled_viewport_width / m_virtual_width;
         }
 
         void Window::set_title(const char * ptitle)

--- a/engine/source/gfx/source/src/Window.cpp
+++ b/engine/source/gfx/source/src/Window.cpp
@@ -4,10 +4,14 @@
 #include <utility>
 namespace gfx
 {
-        Window::Window(int width, int height, const char * ptitle) : 
-                m_width(width), m_height(height), m_title(ptitle)
+        Window::Window(int width, int height, float scale, const char * ptitle) : 
+                m_virtual_width(width), m_virtual_height(height),
+                m_virtual_aspect_ratio((float)width / height), m_scale(scale),
+                m_width(width * scale), m_height(height * scale), m_title(ptitle)
         {
-                m_pglfw_window = glfwCreateWindow(width, height, ptitle, NULL, NULL);
+                m_pglfw_window = glfwCreateWindow(m_width, m_height, ptitle, NULL, NULL);
+                glfwSetWindowSizeLimits(m_pglfw_window, m_virtual_width, m_virtual_height,
+                                        GLFW_DONT_CARE, GLFW_DONT_CARE);
         }
 
 

--- a/engine/source/gfx/source/src/Window.hpp
+++ b/engine/source/gfx/source/src/Window.hpp
@@ -37,6 +37,10 @@ namespace gfx
         private:
                 void                    destroy();
                 GLFWwindow *            m_pglfw_window;
+                int                     m_virtual_width;
+                int                     m_virtual_height;
+                float                   m_virtual_aspect_ratio;
+                float                   m_scale;
                 int                     m_width;
                 int                     m_height;
                 std::string             m_title;

--- a/engine/source/gfx/source/src/Window.hpp
+++ b/engine/source/gfx/source/src/Window.hpp
@@ -28,6 +28,7 @@ namespace gfx
 
                                         ~Window();
 
+                void                    update_viewport();
                 std::pair<int, int>     get_framebuffer_size() const;
                 void                    set_title(const char * ptitle);
                 void                    set_size(int width, int height);

--- a/engine/source/gfx/source/src/Window.hpp
+++ b/engine/source/gfx/source/src/Window.hpp
@@ -18,7 +18,8 @@ namespace gfx
         class Window {
                 friend class Glfw_manager;
         public:
-                                        Window(int width, int height, const char * ptitle);
+                                        Window(int width, int height, float scale,
+                                               const char * ptitle);
                                         Window(Window &) = delete;
                                         Window(Window &&) = delete;
                                         

--- a/engine/source/level_management/source/src/Level_manager.cpp
+++ b/engine/source/level_management/source/src/Level_manager.cpp
@@ -83,23 +83,6 @@ namespace level_management
          */
         void Level_manager::init()
         {
-                //set the current and target aspect ratio of the screen
-                m_curr_aspect_ratio = static_cast<float>(m_ptile_map->width()) / static_cast<float>(m_ptile_map->height());
-                m_target_aspect_ratio = m_curr_aspect_ratio;
-
-                //set variables to control the aspect ratio if the user changes the screen dimensions
-
-                gfx::Window * prender_window = gfx::g_graphics_mgr.get_render_window();
-                std::pair<int, int> window_dimensions = prender_window->get_framebuffer_size();
-                
-                //gfx::g_graphics_mgr.get_framebuffer_size(&m_prev_vport_width, &m_prev_vport_height);
-                m_prev_vport_width = window_dimensions.first;
-                m_prev_vport_height = window_dimensions.second;
-
-                gfx::g_graphics_mgr.set_viewport(0, 0, m_prev_vport_width, m_prev_vport_height);
-                m_curr_vport_width = m_prev_vport_width;
-                m_curr_vport_height = m_prev_vport_height;
-
                 //initialize camera
                 float tile_wld_width = m_ptile_map->tile_width() / gfx::g_graphics_mgr.get_pixels_per_wld_unit();
                 float tile_wld_height = m_ptile_map->tile_height() / gfx::g_graphics_mgr.get_pixels_per_wld_unit();

--- a/engine/source/level_management/source/src/Level_manager.cpp
+++ b/engine/source/level_management/source/src/Level_manager.cpp
@@ -226,30 +226,7 @@ namespace level_management
                                                  plevel_camera->get_view().value_ptr());
 
                 gfx::Window * prender_window = gfx::g_graphics_mgr.get_render_window();
-                std::pair<int, int> window_dimensions = prender_window->get_framebuffer_size();
-                //gfx::g_graphics_mgr.get_framebuffer_size(&m_curr_vport_width, &m_curr_vport_height);
-                m_curr_vport_width = window_dimensions.first;
-                m_curr_vport_height = window_dimensions.second;
-
-                if ((m_curr_vport_width != m_prev_vport_width) || (m_curr_vport_height != m_prev_vport_height)) {
-                        m_curr_aspect_ratio = (float)m_curr_vport_width / (float)m_curr_vport_height;
-
-                        int width = m_curr_vport_width;
-                        int height = (width / m_target_aspect_ratio + 0.5f);
-
-                        if (height > m_curr_vport_height) {
-                                height = m_curr_vport_height;
-                                width = (height * m_target_aspect_ratio + 0.5f);
-                        }
-                        int vp_x = (m_curr_vport_width / 2.0f) - (width / 2);
-                        int vp_y = (m_curr_vport_height / 2.0f) - (height / 2);
-                        int vp_width = width + vp_x;
-                        int vp_height = height + vp_y;
-                        gfx::g_graphics_mgr.set_viewport(vp_x, vp_y, width, height);
-
-                        m_prev_vport_width = m_curr_vport_width;
-                        m_prev_vport_height = m_curr_vport_height;
-                }
+                prender_window->update_viewport();
 
                 m_psprite_shader->uniform_matrix4fv(m_sprites_view_loc, 1, false,
                                                     plevel_camera->get_view().value_ptr());

--- a/engine/source/level_management/source/src/Level_manager.hpp
+++ b/engine/source/level_management/source/src/Level_manager.hpp
@@ -36,12 +36,6 @@ namespace level_management
                 float                                           m_delta_time_seconds;
                 float                                           m_lag;
                 static const float                              m_dt;
-                float                                           m_target_aspect_ratio;
-                float                                           m_curr_aspect_ratio;
-                int                                             m_prev_vport_width;
-                int                                             m_prev_vport_height;
-                int                                             m_curr_vport_width;
-                int                                             m_curr_vport_height;
                 int32_t                                         m_sprites_view_loc;
                 int32_t                                         m_tile_map_view_loc;
                 bool                                            m_should_restart;

--- a/engine/source/src/engine.cpp
+++ b/engine/source/src/engine.cpp
@@ -11,6 +11,7 @@
 #include "Glfw_manager.hpp"
 #include "Graphics_manager.hpp"
 #include "World.hpp"
+#include "Tile_map.hpp"
 #include "Physics_manager.hpp"
 #include "Game_object_manager.hpp"
 #include "Projectile_manager.hpp"
@@ -37,7 +38,8 @@ void engine_init(const uint32_t context_version_major, const uint32_t context_ve
         // Initalize GLFW library
         gfx::Glfw_manager::init(context_version_major, context_version_minor);
         // Initialize the  engine global managers
-        gfx::g_graphics_mgr.init(512, 480, "2D Game Project");
+        gfx::g_graphics_mgr.init(256, 240, 2.0f, "2D Game Project",
+                                 ptile_map->pixels_per_world_unit());
         physics_2d::g_physics_mgr.init(ptile_map);
         gom::g_game_object_mgr.init();
         gom::g_projectile_mgr.init();

--- a/engine/source/tmap/source/src/Tile_map.cpp
+++ b/engine/source/tmap/source/src/Tile_map.cpp
@@ -33,7 +33,7 @@ parse map header/element
 
 static const Tile g_empty_tile;
 
-Tile_map::Tile_map(const std::string & tmx_file_path, float pixels_per_unit) : m_pixels_per_word_unit(pixels_per_unit)
+Tile_map::Tile_map(const std::string & tmx_file_path)
 {
         std::ifstream file_istream;
         std::string   line;
@@ -260,6 +260,8 @@ void Tile_map::parse_map_element_variables(const std::string & line)
         m_height = height;
         m_tile_width = tile_width;
         m_tile_height = tile_height;
+
+        m_pixels_per_word_unit = m_tile_width;
 }
 
 void Tile_map::parse_tileset(const std::string & tmx_file_path, const std::string & first_line)

--- a/engine/source/tmap/source/src/Tile_map.hpp
+++ b/engine/source/tmap/source/src/Tile_map.hpp
@@ -30,7 +30,7 @@ namespace math { struct Rect; }
 class Tile_map {
 friend std::ostream & print_tile_map(std::ostream & os, const Tile_map & map);
 public:
-        Tile_map(const std::string & tmx_file_path, float pixels_per_unit = 16.0f);
+        Tile_map(const std::string & tmx_file_path);
         //Tile_map() = default;
 	
         /*Tile_map(const std::vector<Tileset> & tilesets, const std::vector<std::vector<std::vector<int>>> & layers ,const int layer_count, const int width, const int height, const int tile_width, const int tile_height) : m_pixels_per_word_unit(16)


### PR DESCRIPTION
### Description
  This PR, regarding NO-51, implements the screen scaling functionality on the Window class. This feature is used whenever the user changes the window's size. It allows the window's viewport to scale accordingly , without changing it's aspect ratio.

  OBS. This was previously being done in some capacity, by the Level_manager class, but now that code was improved and moved to the Window class.

[Ticket](https://app.hacknplan.com/p/68474/kanban?categoryId=0&boardId=234155&taskId=51&tabId=basicinfo)