### PR TITLE
No-60 Create Main_menu_canvas

### DIFF
--- a/engine/source/gom/source/src/Camera_2d.hpp
+++ b/engine/source/gom/source/src/Camera_2d.hpp
@@ -34,12 +34,11 @@ namespace gom {
         math::Rect     get_screen_rect() const;
 
         void update(const float dt);
-
-		void           set_screen_dim(const float tiles_per_screen_width,
-                                      const float tiles_per_screen_height);
-
 		void		   scale(const float device_aspect_ratio);
+
 	private:
+            void                set_screen_dim(const float tiles_per_screen_width,
+                                               const float tiles_per_screen_height);
             void                update_view();
             void		        follow(const math::vec3 & p);
             math::Transform     m_transform;

--- a/engine/source/gom/source/src/Game_object_manager.cpp
+++ b/engine/source/gom/source/src/Game_object_manager.cpp
@@ -27,8 +27,6 @@ namespace gom
 
         void Game_object_manager::init()
         {
-                m_pmain_camera = nullptr;
-
                 //set up the handle table
                 m_next_free_index = 0;
                 for (size_t i = 0; i < m_MAX_GAME_OBJECTS - 1; ++i) {
@@ -61,11 +59,6 @@ namespace gom
                 //delete creators
                 for (creator_map::iterator it = m_creators.begin(); it != m_creators.end(); ++it) {
                         delete (it->second);
-                }
-
-                // deallocate main camera
-                if (m_pmain_camera) {
-                        delete m_pmain_camera;
                 }
         }
 
@@ -311,8 +304,8 @@ namespace gom
                 return lhs->get_unique_id() < rhs->get_unique_id();
         }
 
-        gom::Camera_2d * Game_object_manager::get_main_camera()
+        gom::Camera_2d & Game_object_manager::get_main_camera()
         {
-                return m_pmain_camera;
+                return m_main_camera;
         }
 }

--- a/engine/source/gom/source/src/Game_object_manager.cpp
+++ b/engine/source/gom/source/src/Game_object_manager.cpp
@@ -311,11 +311,6 @@ namespace gom
                 return lhs->get_unique_id() < rhs->get_unique_id();
         }
 
-        void Game_object_manager::set_main_camera(gom::Camera_2d * pmain_camera)
-        {
-                m_pmain_camera = pmain_camera;
-        }
-
         gom::Camera_2d * Game_object_manager::get_main_camera()
         {
                 return m_pmain_camera;

--- a/engine/source/gom/source/src/Game_object_manager.hpp
+++ b/engine/source/gom/source/src/Game_object_manager.hpp
@@ -54,7 +54,6 @@ namespace gom {
 
                 void                        broadcast_event(Event & event);
 
-                void                        set_main_camera(Camera_2d * pmain_camera);
                 Camera_2d *                 get_main_camera();
         private:
                 Game_object_handle          register_game_object(Game_object *pgame_object,

--- a/engine/source/gom/source/src/Game_object_manager.hpp
+++ b/engine/source/gom/source/src/Game_object_manager.hpp
@@ -5,6 +5,7 @@
 #include <stdint.h>
 
 #include "Game_object.hpp"
+#include "Camera_2d.hpp"
 
 /* Game_object_manager: class responsable to instantiate and store all the game objects
    in the world. All the objects are stored in a handle table and should only be accessed by
@@ -13,7 +14,7 @@
    is able to create a Game_object of the specific type.
  */
 namespace math { struct vec3; }
-namespace gom {class Creator; class Game_object_handle; class Camera_2d; }
+namespace gom {class Creator; class Game_object_handle; }
 class Event;
 
 namespace gom {
@@ -54,7 +55,7 @@ namespace gom {
 
                 void                        broadcast_event(Event & event);
 
-                Camera_2d *                 get_main_camera();
+                Camera_2d &                 get_main_camera();
         private:
                 Game_object_handle          register_game_object(Game_object *pgame_object,
                                                                  std::size_t object_sz);
@@ -72,7 +73,7 @@ namespace gom {
                 vgame_object_handles	   m_game_objects_to_destroy;
 
 
-                Camera_2d               *m_pmain_camera;
+                Camera_2d               m_main_camera;
         };
         extern Game_object_manager g_game_object_mgr;
 

--- a/engine/source/gom/source/src/Projectile.cpp
+++ b/engine/source/gom/source/src/Projectile.cpp
@@ -100,8 +100,8 @@ namespace gom {
 
 	void Projectile::update(const float dt) 
 	{
-            Camera_2d *plevel_camera = g_game_object_mgr.get_main_camera();
-		if (plevel_camera->is_off_camera(m_pbody_2d->get_position(), 1.0F, 1.0F)) {
+            Camera_2d & level_camera = g_game_object_mgr.get_main_camera();
+		if (level_camera.is_off_camera(m_pbody_2d->get_position(), 1.0F, 1.0F)) {
 			set_active(false);
 			return;
 		}

--- a/engine/source/level_management/source/src/Level_manager.cpp
+++ b/engine/source/level_management/source/src/Level_manager.cpp
@@ -124,6 +124,7 @@ namespace level_management
                 Path & resources_path)
         {
                 m_ptile_map = nullptr;
+                m_should_load_next_level = false;
                 m_level_data.reserve(30); // Remove magic number
 
                 m_current_level = 0;

--- a/engine/source/level_management/source/src/Level_manager.cpp
+++ b/engine/source/level_management/source/src/Level_manager.cpp
@@ -55,15 +55,10 @@ namespace level_management
          * but also the location of all the resources necessary to play level, such as textures,
          * animator controllers, sprite atlases, shaders and so on.
          */
-        void Level_manager::load_level(const std::uint32_t level_index)
+        void Level_manager::load_requested_level()
         {
-                if (level_index > m_levels.size() - 1) {
-                        return;
-                }
-
                 unload_current_level();
 
-                m_current_level = level_index;
                 // Load .TMX file containg the map and it's data
                 std::string level("/maps/" + m_levels[m_current_level]);
 

--- a/engine/source/level_management/source/src/Level_manager.cpp
+++ b/engine/source/level_management/source/src/Level_manager.cpp
@@ -236,6 +236,12 @@ namespace level_management
 
         void Level_manager::tick()
         {
+            if (m_should_load_next_level) {
+                load_requested_level();
+                // reset flag
+                m_should_load_next_level = false;
+            }
+
                 io::g_input_mgr.poll_events();
 
                 bool pause_pressed = io::g_input_mgr.get_button_down(SID('pause'));

--- a/engine/source/level_management/source/src/Level_manager.cpp
+++ b/engine/source/level_management/source/src/Level_manager.cpp
@@ -101,9 +101,11 @@ namespace level_management
                 }
         }
 
-        void Level_manager::load_next_level()
+        void Level_manager::request_next_level()
         {
-                load_level(m_current_level + 1);
+                request_level(m_current_level + 1);
+        }
+
         void Level_manager::request_level(const std::uint32_t level_index)
         {
             if (level_index > m_levels.size() - 1) {

--- a/engine/source/level_management/source/src/Level_manager.cpp
+++ b/engine/source/level_management/source/src/Level_manager.cpp
@@ -179,40 +179,30 @@ namespace level_management
                 float tile_wld_height = m_ptile_map->tile_height() / gfx::g_graphics_mgr.get_pixels_per_wld_unit();
                 math::vec2 map_origin = math::vec2(m_ptile_map->get_position().x, m_ptile_map->get_position().y);
 
-                gom::Camera_2d *plevel_camera = gom::g_game_object_mgr.get_main_camera();
-                if (plevel_camera) {
-                        plevel_camera->init(tile_wld_width, tile_wld_height,
-                                            gfx::g_graphics_mgr.get_tiles_per_screen_width(),
-                                            gfx::g_graphics_mgr.get_tiles_per_screen_height(), 
-                                            m_ptile_map->width(),
-                                            m_ptile_map->height(), map_origin);
+                // configure the camera for this level
+                gom::Camera_2d & level_camera = gom::g_game_object_mgr.get_main_camera();
+                level_camera.init(tile_wld_width, tile_wld_height,
+                                  gfx::g_graphics_mgr.get_tiles_per_screen_width(),
+                                  gfx::g_graphics_mgr.get_tiles_per_screen_height(), 
+                                  m_ptile_map->width(),
+                                  m_ptile_map->height(), map_origin);
 
-                }
-                else {
-                        plevel_camera = new gom::Camera_2d(tile_wld_width, tile_wld_height,
-                                                           gfx::g_graphics_mgr.get_tiles_per_screen_width(),
-                                                           gfx::g_graphics_mgr.get_tiles_per_screen_height(), 
-                                                           m_ptile_map->width(),
-                                                           m_ptile_map->height(), map_origin);
-                        // set as the main camera
-                        gom::g_game_object_mgr.set_main_camera(plevel_camera);
-                }
 
                 m_pmap_shader->uniform_matrix4fv(m_tile_map_view_loc, 1, false,
-                                                 plevel_camera->get_view().value_ptr());
+                                                 level_camera.get_view().value_ptr());
 
                 m_pmap_shader->uniform_matrix4fv(m_pmap_shader->get_uniform_location("P"), 1, false,
-                                                 plevel_camera->projection().value_ptr());
+                                                 level_camera.projection().value_ptr());
 
                 m_pmap_shader->uniform_1f(m_pmap_shader->get_uniform_location("tileset1"), 0);
                 gfx::g_graphics_mgr.set_tile_map_shader(m_pmap_shader);
 
 
                 m_psprite_shader->uniform_matrix4fv(m_sprites_view_loc, 1, false,
-                                                    plevel_camera->get_view().value_ptr());
+                                                    level_camera.get_view().value_ptr());
 
                 m_psprite_shader->uniform_matrix4fv(m_psprite_shader->get_uniform_location("P"), 1,
-                                                    false, plevel_camera->projection().value_ptr());
+                                                    false, level_camera.projection().value_ptr());
 
                 m_psprite_shader->uniform_1f(m_psprite_shader->get_uniform_location("tileset"), 0);
                 gfx::g_graphics_mgr.set_sprite_shader(m_psprite_shader);
@@ -295,18 +285,18 @@ namespace level_management
                 gom::g_projectile_mgr.update(game_delta_time_seconds);
 
                 //update the level's camera
-                gom::Camera_2d * plevel_camera = gom::g_game_object_mgr.get_main_camera();
+                gom::Camera_2d & level_camera = gom::g_game_object_mgr.get_main_camera();
                 
-                plevel_camera->update(game_delta_time_seconds);
+                level_camera.update(game_delta_time_seconds);
                 
                 m_pmap_shader->uniform_matrix4fv(m_tile_map_view_loc, 1, false,
-                                                 plevel_camera->get_view().value_ptr());
+                                                 level_camera.get_view().value_ptr());
 
                 gfx::Window * prender_window = gfx::g_graphics_mgr.get_render_window();
                 prender_window->update_viewport();
 
                 m_psprite_shader->uniform_matrix4fv(m_sprites_view_loc, 1, false,
-                                                    plevel_camera->get_view().value_ptr());
+                                                    level_camera.get_view().value_ptr());
 
                 gfx::g_graphics_mgr.render();
 

--- a/engine/source/level_management/source/src/Level_manager.cpp
+++ b/engine/source/level_management/source/src/Level_manager.cpp
@@ -104,6 +104,18 @@ namespace level_management
         void Level_manager::load_next_level()
         {
                 load_level(m_current_level + 1);
+        void Level_manager::request_level(const std::uint32_t level_index)
+        {
+            if (level_index > m_levels.size() - 1) {
+                return;
+            }
+
+            if (m_should_load_next_level) {
+                return;
+            }
+
+            m_current_level = level_index;
+            m_should_load_next_level = true;
         }
 
         void Level_manager::load_resident_data(const char * pplevels[], const uint32_t num_levels,

--- a/engine/source/level_management/source/src/Level_manager.hpp
+++ b/engine/source/level_management/source/src/Level_manager.hpp
@@ -21,7 +21,7 @@ namespace level_management
                                                    const uint32_t num_levels,
                                                    Path & resources_path);
                 void load_next_level();
-                void load_level(const uint32_t level_index);
+                void request_level(const uint32_t level_index);
 
                 void shut_down();
                 void tick();

--- a/engine/source/level_management/source/src/Level_manager.hpp
+++ b/engine/source/level_management/source/src/Level_manager.hpp
@@ -32,6 +32,7 @@ namespace level_management
                 void            init();
                 void            instantiate_level_objects();
                 void            unload_current_level();
+                void            load_requested_level();
                 Path*                                           m_presources_path = nullptr;
                 std::vector<Game_object_data>                   m_level_data;
                 Tile_map*                                       m_ptile_map;
@@ -48,6 +49,7 @@ namespace level_management
                 std::vector<std::string>                        m_levels;
                 std::vector<std::string>::size_type             m_current_level;
                 bool                                            m_should_restart;
+                bool                                            m_should_load_next_level;
 
         };
         extern Level_manager g_level_mgr;

--- a/engine/source/level_management/source/src/Level_manager.hpp
+++ b/engine/source/level_management/source/src/Level_manager.hpp
@@ -20,7 +20,7 @@ namespace level_management
                 void            load_resident_data(const char * pplevels[],
                                                    const uint32_t num_levels,
                                                    Path & resources_path);
-                void load_next_level();
+                void request_next_level();
                 void request_level(const uint32_t level_index);
 
                 void shut_down();

--- a/engine/source/src/engine.cpp
+++ b/engine/source/src/engine.cpp
@@ -50,9 +50,7 @@ void engine_init(const uint32_t context_version_major, const uint32_t context_ve
                                             io::Input_abstraction_layer::keyboard_callback);
 
         Path resources_path("../resources", Path::FORWARD_SLASH);
-        // this should be load_resilient_data
         level_management::g_level_mgr.load_resident_data(pplevels, num_levels, resources_path);
-        //level_management::g_level_mgr.load(resources_path, ptile_map);
 
         // set Engine's default collision listener
         pcollision_listener = new Engine_collision_listener;

--- a/engine/source/src/engine.cpp
+++ b/engine/source/src/engine.cpp
@@ -47,7 +47,7 @@ void engine_init(const uint32_t context_version_major, const uint32_t context_ve
 
         gfx::Glfw_manager::set_error_callback(error_callback);
         gfx::Glfw_manager::set_key_callback(gfx::g_graphics_mgr.get_render_window(),
-                io::Input_abstraction_layer::keyboard_callback);
+                                            io::Input_abstraction_layer::keyboard_callback);
 
         Path resources_path("../resources", Path::FORWARD_SLASH);
         // this should be load_resilient_data

--- a/engine/source/ui/source/src/Canvas.cpp
+++ b/engine/source/ui/source/src/Canvas.cpp
@@ -11,6 +11,7 @@
 #include "Resource.hpp"
 #include "Sprite_atlas.hpp"
 #include "Sprite_atlas_manager.hpp"
+#include "UI_manager.hpp"
 
 #include "runtime_memory_allocator.hpp"
 
@@ -26,10 +27,17 @@ namespace ui
     const std::uint8_t    Canvas::s_MAX_NUM_VERTICES_PER_WIDGET;
 
 
-        Canvas::Canvas(const math::Rect & rect, const string_id atlas_id) :
-                gom::Game_object(sizeof(Canvas), math::g_zero_vec3), m_num_widgets(0),
-                m_dirty(true), m_atlas_id(atlas_id), m_rect(rect),
-                m_vertex_batch(s_max_num_vertices_per_widget * s_max_num_widgets, true) {}
+    Canvas::Canvas(const math::Rect & rect, const string_id atlas_id, const std::size_t obj_size) :
+        gom::Game_object(obj_size, math::g_zero_vec3), m_num_widgets(0), m_dirty(true),
+        m_atlas_id(atlas_id), m_rect(rect),
+        m_vertex_batch(s_MAX_NUM_VERTICES_PER_WIDGET * s_MAX_NUM_WIDGETS, true)
+    {
+        if (!g_ui_mgr.add_canvas(*this)) {
+#ifndef NDEBUG
+            std::cerr << "ERROR: Unable to add canvas to UI_MANAGER" << std::endl;
+#endif // !NDEBUG
+        }
+    }
 
         void Canvas::update(const float dt) {}
         void Canvas::on_event(Event & event) {}

--- a/engine/source/ui/source/src/Canvas.cpp
+++ b/engine/source/ui/source/src/Canvas.cpp
@@ -1,5 +1,4 @@
 #include "Canvas.hpp"
-#include "Game_object.hpp"
 #include "Widget.hpp"
 #include "Text.hpp"
 #include "Vertex1P1C1UV.hpp"
@@ -8,7 +7,6 @@
 #include "Game_object_manager.hpp"
 #include "Event.hpp"
 #include "string_id.hpp"
-#include "Resource.hpp"
 #include "Sprite_atlas.hpp"
 #include "Sprite_atlas_manager.hpp"
 #include "UI_manager.hpp"

--- a/engine/source/ui/source/src/Canvas.cpp
+++ b/engine/source/ui/source/src/Canvas.cpp
@@ -22,8 +22,8 @@
 
 namespace ui
 {
-        const std::uint8_t    Canvas::s_max_num_widgets;
-        const std::uint8_t    Canvas::s_max_num_vertices_per_widget;
+    const std::uint8_t    Canvas::s_MAX_NUM_WIDGETS;
+    const std::uint8_t    Canvas::s_MAX_NUM_VERTICES_PER_WIDGET;
 
 
         Canvas::Canvas(const math::Rect & rect, const string_id atlas_id) :

--- a/engine/source/ui/source/src/Canvas.cpp
+++ b/engine/source/ui/source/src/Canvas.cpp
@@ -37,67 +37,66 @@ namespace ui
         }
     }
 
-        void Canvas::update(const float dt) {}
-        void Canvas::on_event(Event & event) {}
+    void Canvas::update(const float dt) {}
+    void Canvas::on_event(Event & event) {}
 
-        Canvas * Canvas::add_widget(const Widget & widget)
-        {
-                if (m_num_widgets >= s_max_num_widgets) {
-                        return nullptr;
-                }
-
-                m_widgets[m_num_widgets++].bind(widget);
-                return this;
+    bool Canvas::add_widget(const Widget & widget)
+    {
+        if (m_num_widgets >= s_MAX_NUM_WIDGETS) {
+            return false;
         }
 
-        gfx::Sprite_atlas * Canvas::get_atlas()
-        {
-                rms::Resource * pres = gfx::g_sprite_atlas_mgr.get_by_id(m_atlas_id);
-                if (pres) {
-                        return static_cast<gfx::Sprite_atlas*>(pres);
-                }
-                return nullptr;
+        m_widgets[m_num_widgets++].bind(widget);
+        return true;
+    }   
+
+    gfx::Sprite_atlas * Canvas::get_atlas()
+    {
+        rms::Resource * pres = gfx::g_sprite_atlas_mgr.get_by_id(m_atlas_id);
+        if (pres) {
+            return static_cast<gfx::Sprite_atlas*>(pres);
         }
+            return nullptr;
+    }
 
-        void Canvas::render()
-        {
-                if (m_dirty) {
-                        // Clear the vertex buffer
-                        m_vertex_batch.reset();
+    void Canvas::render()
+    {
+        if (m_dirty) {
+            // Clear the vertex buffer
+            m_vertex_batch.reset();
 
-                        // recalculate the widgets vertices
-                        std::uint8_t i = 0;
-                        Widget::vertex_data rendering_data;
-                        gom::Game_object *pgame_object = nullptr;
-                        Widget *pwidget = nullptr;
-                        for (i; i != m_num_widgets; ++i) {
-                                pgame_object = gom::g_game_object_mgr.get_by_handle(m_widgets[i]);
-                                // We need to find a way to remove this handle if the object was destroyed!
-                                // Perhaps the best solution is indeed to use a std::vector
-                                if (!pgame_object) {
-                                        continue;
-                                }
-                                if (!pgame_object->is_active()) {
-                                        continue;
-                                }
+            // recalculate the widgets vertices
+            std::uint8_t i = 0;
+            Widget::vertex_data rendering_data;
+            gom::Game_object *pgame_object = nullptr;
+            Widget *pwidget = nullptr;
+            for (i; i != m_num_widgets; ++i) {
+                pgame_object = gom::g_game_object_mgr.get_by_handle(m_widgets[i]);
 
-                                pwidget = static_cast<Widget*>(pgame_object);
-                                rendering_data = pwidget->get_view_space_vertices();
-                                if (rendering_data.first == nullptr || rendering_data.second == 0) {
-                                        continue;
-                                }
-
-                                m_vertex_batch.add(rendering_data.first, rendering_data.second);
-                        }
-                        m_dirty = false;
+                if (!pgame_object) {
+                    continue;
                 }
-                m_vertex_batch.render();
-        }
-
-        Canvas::~Canvas()
-        {
-                for (std::uint8_t i = 0; i != m_num_widgets; ++i) {
-                        gom::g_game_object_mgr.request_destruction(m_widgets[i]);
+                if (!pgame_object->is_active()) {
+                    continue;
                 }
+
+                pwidget = static_cast<Widget*>(pgame_object);
+                rendering_data = pwidget->get_view_space_vertices();
+                if (rendering_data.first == nullptr || rendering_data.second == 0) {
+                    continue;
+                }
+
+                m_vertex_batch.add(rendering_data.first, rendering_data.second);
+            }
+            m_dirty = false;
         }
+        m_vertex_batch.render();
+    }
+
+    Canvas::~Canvas()
+    {
+        for (std::uint8_t i = 0; i != m_num_widgets; ++i) {
+            gom::g_game_object_mgr.request_destruction(m_widgets[i]);
+        }
+    }
 }

--- a/engine/source/ui/source/src/Canvas.hpp
+++ b/engine/source/ui/source/src/Canvas.hpp
@@ -7,7 +7,6 @@
 #include "Sprite_batch.hpp"
 #include "string_id.hpp"
 #include <cstdint>
-#include <string>
 
 namespace ui { class Widget; class Text; class UI_manager; }
 namespace gfx { class Sprite_atlas; }
@@ -15,31 +14,35 @@ class Event;
 
 namespace ui
 {
-        class Canvas final : public gom::Game_object {
-                friend class UI_manager;
-        public:
-                Canvas * add_widget(const Widget & widget);
-                bool is_dirty() const { return m_dirty; }
-                void set_dirty_flag(const bool is_dirty) { m_dirty = is_dirty; }
+    class Canvas : public gom::Game_object {
+        friend class UI_manager;
+    public:
+        Canvas(const math::Rect & rect, const string_id atlas_id,
+               const std::size_t obj_size = sizeof(Canvas));
+        Canvas(const Canvas &) = delete;
+        ~Canvas();
 
-                virtual void                 update(float dt) override;
-                virtual void                 on_event(Event & event) override;
-                                             ~Canvas();
-                gfx::Sprite_atlas *    get_atlas();
+        Canvas & operator=(const Canvas &) = delete;
+        bool add_widget(const Widget & widget);
 
-        private:
-                explicit                     Canvas(const math::Rect & rect,
-                                                    const string_id atlas_id);
-                void                         render();
-                static const std::uint8_t    s_max_num_widgets = 10;
-                static const std::uint8_t    s_max_num_vertices_per_widget = 48; 
-                std::uint8_t                 m_num_widgets;
-                bool                         m_dirty;
-                string_id                    m_atlas_id;
-                math::Rect                   m_rect;
-                gfx::Sprite_batch            m_vertex_batch;
-                gom::Game_object_handle      m_widgets[s_max_num_widgets];
-        };
+        void    set_dirty_flag(const bool is_dirty) { m_dirty = is_dirty; }
+        virtual void    update(float dt) override;
+        virtual void    on_event(Event & event) override;
+
+        bool is_dirty() const { return m_dirty; }
+        gfx::Sprite_atlas *    get_atlas();
+
+    private:
+        void                         render();
+        static const std::uint8_t    s_MAX_NUM_WIDGETS = 10;
+        static const std::uint8_t    s_MAX_NUM_VERTICES_PER_WIDGET = 48;
+        std::uint8_t                 m_num_widgets;
+        bool                         m_dirty;
+        string_id                    m_atlas_id;
+        math::Rect                   m_rect;
+        gfx::Sprite_batch            m_vertex_batch;
+        gom::Game_object_handle      m_widgets[s_MAX_NUM_WIDGETS];
+    };
 }
 
 #endif // !_CANVAS_HPP

--- a/engine/source/ui/source/src/Text.cpp
+++ b/engine/source/ui/source/src/Text.cpp
@@ -1,6 +1,5 @@
 #include "Text.hpp"
 
-#include "Widget.hpp"
 #include "Canvas.hpp"
 #include "UI_manager.hpp"
 #include "Rect.hpp"
@@ -17,151 +16,150 @@
 
 namespace ui
 {
-        Text::Text(Canvas & parent_canvas, const std::string & msg, const std::size_t obj_sz,
-                   const float scale_factor, const int characters_space,
-                   const int space_character_sz) :
-                Widget(parent_canvas, math::Rect(), obj_sz), m_scale_factor(scale_factor),
-                m_characters_space(characters_space), m_space_character_sz(space_character_sz),
-                m_characters_ids(msg.size()), m_msg(msg)
-        {
-                for (unsigned i = 0; i != msg.size(); ++i) {
-                        m_characters_ids[i] = get_crc32(m_msg[i]);
-                }
-                set_obj_space_rect();
+    Text::Text(Canvas & parent_canvas, const std::string & msg, const std::size_t obj_sz,
+               const float scale_factor, const int characters_space, const int space_character_sz) :
+        Widget(parent_canvas, math::Rect(), obj_sz), m_scale_factor(scale_factor),
+        m_characters_space(characters_space), m_space_character_sz(space_character_sz),
+        m_characters_ids(msg.size()), m_msg(msg)
+    {
+        for (unsigned i = 0; i != msg.size(); ++i) {
+            m_characters_ids[i] = get_crc32(m_msg[i]);
+        }
+        generate_obj_space_rect();
+    }
+
+    void Text::generate_obj_space_rect()
+    {
+        if (m_characters_ids.empty()) {
+            return;
         }
 
-        void Text::set_obj_space_rect()
-        {
-                if (m_characters_ids.empty()) {
-                        return;
-                }
+        const float pixels_per_wld_unit = gfx::g_graphics_mgr.get_pixels_per_wld_unit();
+        const float space_char_sz = (m_space_character_sz / pixels_per_wld_unit * m_scale_factor);
+        const float space_between_chars = (m_characters_space / pixels_per_wld_unit * m_scale_factor);
 
-                const float pixels_per_wld_unit = gfx::g_graphics_mgr.get_pixels_per_wld_unit();
-                const float space_char_sz = (m_space_character_sz / pixels_per_wld_unit * m_scale_factor);
-                const float space_between_chars = (m_characters_space / pixels_per_wld_unit * m_scale_factor);
+        float height = 0.0f;
+        float width = 0.0f;
 
-                float height = 0.0f;
-                float width = 0.0f;
+        const gfx::Sprite_atlas * atlas = m_pparent_canvas->get_atlas();
+        for (std::size_t i = 0; i != m_characters_ids.size(); ++i) {
+            const gfx::Atlas_image & image = atlas->get_image_data(m_characters_ids[i]);
+            float char_width_wld_units = (image.m_width * m_scale_factor) / pixels_per_wld_unit;
+            float char_height_wld_units = (image.m_height * m_scale_factor) / pixels_per_wld_unit;
 
-                const gfx::Sprite_atlas * atlas = m_pparent_canvas->get_atlas();
-                for (std::size_t i = 0; i != m_characters_ids.size(); ++i) {
-                        const gfx::Atlas_image & image = atlas->get_image_data(m_characters_ids[i]);
-                        float char_width_wld_units = (image.m_width * m_scale_factor) / pixels_per_wld_unit;
-                        float char_height_wld_units = (image.m_height * m_scale_factor) / pixels_per_wld_unit;
+            // check if it is a a space character
+            if (image.m_width == 0 && image.m_height == 0) {
+                width += space_char_sz;;
+                continue;
+            }
 
-                        // check if it is a a space character
-                        if (image.m_width == 0 && image.m_height == 0) {
-                                width += space_char_sz;;
-                                continue;
-                        }
+            width += char_width_wld_units + space_between_chars;
+            if (height < char_height_wld_units) {
+                height = char_height_wld_units;
+            }
+        }
+        width -= space_between_chars;
 
-                        width += char_width_wld_units + space_between_chars; 
-                        if (height < char_height_wld_units) {
-                                height = char_height_wld_units;
-                        }
-                }
-                width -= space_between_chars;
+        // account for floating point error
+        width += (1 * m_scale_factor) / pixels_per_wld_unit;
+        m_obj_space_aabb = math::Rect(-width / 2.0f, height / 2.0f, width, height);
+    }
 
-                // account for floating point error
-                width += (1 * m_scale_factor) / pixels_per_wld_unit;
-                m_obj_space_aabb =  math::Rect(-width / 2.0f, height / 2.0f, width, height);
+    // TODO: We need to handle the case of the get_tlas function returning a null pointer
+    // in this case, we probably should have a default texture to use, an 'error texture'.
+    // Another idea would be to use the color of the vertices to render something different
+    // to alert about the missing texture atlas.
+    Widget::vertex_data Text::get_view_space_vertices() const
+    {
+        if (m_characters_ids.empty()) {
+            return std::make_pair(nullptr, 0);
+        }
+        math::Rect canvas_space_bb(m_obj_space_aabb);
+        canvas_space_bb.x += m_obj_to_canvas_translation.x;
+        canvas_space_bb.y += m_obj_to_canvas_translation.y;
+
+        math::vec4  bottom_left_pos(canvas_space_bb.min());
+        math::vec4  bottom_right_pos(bottom_left_pos.x + canvas_space_bb.width,
+            bottom_left_pos.y);
+        math::vec4  top_right_pos(canvas_space_bb.max());
+        math::vec4  top_left_pos(canvas_space_bb.x, canvas_space_bb.y);
+
+        const math::mat4 & view_space = m_pparent_canvas->get_transform_component()
+            .get_object_to_world();
+
+        // Transform the vertices 
+        bottom_left_pos *= view_space;
+        bottom_right_pos *= view_space;
+        top_right_pos *= view_space;
+        top_left_pos *= view_space;
+
+        math::vec3 char_bottom_left(bottom_left_pos.x, bottom_left_pos.y, 0.0f);
+        const float pixels_per_wld_unit = gfx::g_graphics_mgr.get_pixels_per_wld_unit();
+        const int vertex_sz = 6;
+
+        const float space_char_sz = (m_space_character_sz / pixels_per_wld_unit * m_scale_factor);
+        const float space_between_chars = (m_characters_space / pixels_per_wld_unit * m_scale_factor);
+
+        const gfx::Sprite_atlas * atlas = m_pparent_canvas->get_atlas();
+        gfx::Vertex1P1C1UV *pbuffer = ui::g_vertex_buffer;
+        std::size_t i = 0;
+        for (; i != m_characters_ids.size(); ++i) {
+            const gfx::Atlas_image & image = atlas->get_image_data(m_characters_ids[i]);
+            float char_width_wld_units = (image.m_width * m_scale_factor) / pixels_per_wld_unit;
+            float char_height_wld_units = (image.m_height * m_scale_factor) / pixels_per_wld_unit;
+            const math::Rect & tcoordinates = image.m_texture_coordinates;
+
+            // check if there is space on buffer for text
+            if ((vertex_sz * i + vertex_sz - 1) > ui::g_VERTEX_BUFFER_SZ - 1) {
+                std::cerr << "ERRROR: ATTEMPTING TO ACESS OUT OF ARRAY MEMORY!!" << std::endl;
+                break;
+            }
+
+
+            // check if it is a a space character
+            if (image.m_width == 0 && image.m_height == 0) {
+                char_bottom_left.x += space_char_sz;
+                continue;
+            }
+
+            // check if the new character fits on the text's rect
+            if (char_bottom_left.x + char_width_wld_units > bottom_right_pos.x) {
+                break;
+            }
+
+            const std::size_t start_index = vertex_sz * i;
+            pbuffer[start_index].m_pos = char_bottom_left;
+            pbuffer[start_index].m_uv.x = tcoordinates.x;
+            pbuffer[start_index].m_uv.y = tcoordinates.y + tcoordinates.height;
+
+            pbuffer[start_index + 1].m_pos.x = char_bottom_left.x + char_width_wld_units;
+            pbuffer[start_index + 1].m_pos.y = char_bottom_left.y;
+            pbuffer[start_index + 1].m_pos.z = 0.0f;
+            pbuffer[start_index + 1].m_uv.x = tcoordinates.x + tcoordinates.width;
+            pbuffer[start_index + 1].m_uv.y = tcoordinates.y + tcoordinates.height;
+
+            pbuffer[start_index + 2].m_pos.x = char_bottom_left.x + char_width_wld_units;
+            pbuffer[start_index + 2].m_pos.y = char_bottom_left.y + char_height_wld_units;
+            pbuffer[start_index + 2].m_pos.z = 0.0f;
+            pbuffer[start_index + 2].m_uv.x = tcoordinates.x + tcoordinates.width;
+            pbuffer[start_index + 2].m_uv.y = tcoordinates.y;
+
+            pbuffer[start_index + 3].m_pos = pbuffer[start_index + 2].m_pos;
+            pbuffer[start_index + 3].m_uv = pbuffer[start_index + 2].m_uv;
+
+            pbuffer[start_index + 4].m_pos.x = char_bottom_left.x;
+            pbuffer[start_index + 4].m_pos.y = char_bottom_left.y + char_height_wld_units;
+            pbuffer[start_index + 4].m_pos.z = 0.0f;
+            pbuffer[start_index + 4].m_uv.x = tcoordinates.x;
+            pbuffer[start_index + 4].m_uv.y = tcoordinates.y;
+
+            pbuffer[start_index + 5].m_pos = pbuffer[start_index].m_pos;
+            pbuffer[start_index + 5].m_uv = pbuffer[start_index].m_uv;
+
+            char_bottom_left.x += char_width_wld_units + space_between_chars;
         }
 
-        // TODO: We need to handle the case of the get_tlas function returning a null pointer
-        // in this case, we probably should have a default texture to use, an 'error texture'.
-        // Another idea would be to use the color of the vertices to render something different
-        // to alert about the missing texture atlas.
-        Widget::vertex_data Text::get_view_space_vertices() const
-        {
-                if (m_characters_ids.empty()) {
-                        return std::make_pair(nullptr, 0);
-                }
-                math::Rect canvas_space_bb(m_obj_space_aabb);
-                canvas_space_bb.x += m_obj_to_canvas_translation.x;
-                canvas_space_bb.y += m_obj_to_canvas_translation.y;
-
-                math::vec4  bottom_left_pos(canvas_space_bb.min());
-                math::vec4  bottom_right_pos(bottom_left_pos.x + canvas_space_bb.width,
-                                             bottom_left_pos.y);
-                math::vec4  top_right_pos(canvas_space_bb.max());
-                math::vec4  top_left_pos(canvas_space_bb.x, canvas_space_bb.y);
-
-                const math::mat4 & view_space = m_pparent_canvas->get_transform_component()
-                                                                  .get_object_to_world();
-
-                // Transform the vertices 
-                bottom_left_pos *= view_space;
-                bottom_right_pos *= view_space;
-                top_right_pos *= view_space;
-                top_left_pos *= view_space;
-
-                math::vec3 char_bottom_left(bottom_left_pos.x, bottom_left_pos.y, 0.0f);
-                const float pixels_per_wld_unit = gfx::g_graphics_mgr.get_pixels_per_wld_unit();
-                const int vertex_sz = 6;
-
-                const float space_char_sz = (m_space_character_sz / pixels_per_wld_unit * m_scale_factor);
-                const float space_between_chars = (m_characters_space / pixels_per_wld_unit * m_scale_factor);
-
-                const gfx::Sprite_atlas * atlas = m_pparent_canvas->get_atlas();
-                gfx::Vertex1P1C1UV *pbuffer = ui::g_vertex_buffer;
-                std::size_t i = 0;
-                for (; i != m_characters_ids.size(); ++i) {
-                        const gfx::Atlas_image & image = atlas->get_image_data(m_characters_ids[i]);
-                        float char_width_wld_units = (image.m_width * m_scale_factor) / pixels_per_wld_unit;
-                        float char_height_wld_units = (image.m_height * m_scale_factor) / pixels_per_wld_unit;
-                        const math::Rect & tcoordinates = image.m_texture_coordinates;
-
-                        // check if there is space on buffer for text
-                        if ((vertex_sz * i + vertex_sz - 1) > ui::g_vertex_buffer_sz - 1) {
-                                std::cerr << "ERRROR: ATTEMPTING TO ACESS OUT OF ARRAY MEMORY!!" << std::endl;
-                                break;
-                        }
-
-
-                        // check if it is a a space character
-                        if (image.m_width == 0 && image.m_height == 0) {
-                                char_bottom_left.x += space_char_sz;
-                                continue;
-                        }
-
-                        // check if the new character fits on the text's rect
-                        if (char_bottom_left.x + char_width_wld_units > bottom_right_pos.x) {
-                                break;
-                        }
-
-                        const std::size_t start_index = vertex_sz * i;
-                        pbuffer[start_index].m_pos = char_bottom_left;
-                        pbuffer[start_index].m_uv.x = tcoordinates.x;
-                        pbuffer[start_index].m_uv.y = tcoordinates.y + tcoordinates.height;
-
-                        pbuffer[start_index + 1].m_pos.x = char_bottom_left.x + char_width_wld_units;
-                        pbuffer[start_index + 1].m_pos.y = char_bottom_left.y;
-                        pbuffer[start_index + 1].m_pos.z = 0.0f;
-                        pbuffer[start_index + 1].m_uv.x = tcoordinates.x + tcoordinates.width;
-                        pbuffer[start_index + 1].m_uv.y = tcoordinates.y + tcoordinates.height;
-
-                        pbuffer[start_index + 2].m_pos.x = char_bottom_left.x + char_width_wld_units;
-                        pbuffer[start_index + 2].m_pos.y = char_bottom_left.y + char_height_wld_units;
-                        pbuffer[start_index + 2].m_pos.z = 0.0f;
-                        pbuffer[start_index + 2].m_uv.x = tcoordinates.x + tcoordinates.width;
-                        pbuffer[start_index + 2].m_uv.y = tcoordinates.y;
-
-                        pbuffer[start_index + 3].m_pos = pbuffer[start_index + 2].m_pos;
-                        pbuffer[start_index + 3].m_uv  = pbuffer[start_index + 2].m_uv;
-
-                        pbuffer[start_index + 4].m_pos.x = char_bottom_left.x;
-                        pbuffer[start_index + 4].m_pos.y = char_bottom_left.y + char_height_wld_units;
-                        pbuffer[start_index + 4].m_pos.z = 0.0f;
-                        pbuffer[start_index + 4].m_uv.x = tcoordinates.x;
-                        pbuffer[start_index + 4].m_uv.y = tcoordinates.y;
-
-                        pbuffer[start_index + 5].m_pos = pbuffer[start_index].m_pos;
-                        pbuffer[start_index + 5].m_uv = pbuffer[start_index].m_uv;
-
-                        char_bottom_left.x += char_width_wld_units + space_between_chars;
-                }
-
-                return std::make_pair(pbuffer, vertex_sz * i);
-        }
+        return std::make_pair(pbuffer, vertex_sz * i);
+    }
 
 }

--- a/engine/source/ui/source/src/Text.hpp
+++ b/engine/source/ui/source/src/Text.hpp
@@ -24,8 +24,9 @@ namespace ui
                 const std::string &     get_message() const { return m_msg; }
                 float get_scale_factor() const { return m_scale_factor; }
         protected:
-                void set_obj_space_rect();
                 virtual vertex_data     get_view_space_vertices() const override;
+        private:
+                void generate_obj_space_rect();
                 const float m_scale_factor;
                 const int   m_characters_space; // the space in pixels between two caracters on the text
                 const int   m_space_character_sz; // the size in pixels of the 'space' character

--- a/engine/source/ui/source/src/UI_manager.cpp
+++ b/engine/source/ui/source/src/UI_manager.cpp
@@ -43,6 +43,10 @@ namespace ui
         void UI_manager::set_widgets_shader(gfx::Shader & widgets_shader)
         {
                 m_pwidgets_shader = &widgets_shader;
+    bool UI_manager::add_canvas(const Canvas & canvas)
+    {
+        if (m_num_canvases >= s_MAX_NUM_CANVASES) {
+            return false;
         }
 
         // By the default, the canvas should ocupy the entire screen

--- a/engine/source/ui/source/src/UI_manager.cpp
+++ b/engine/source/ui/source/src/UI_manager.cpp
@@ -1,7 +1,5 @@
 #include "UI_manager.hpp"
-#include "Rect.hpp"
 #include "Canvas.hpp"
-#include "runtime_memory_allocator.hpp"
 #include "Camera_2d.hpp"
 #include "Game_object.hpp"
 #include "Game_object_handle.hpp"
@@ -15,79 +13,64 @@
 
 namespace ui
 {
-        const std::size_t        g_vertex_buffer_sz = 156;
-        gfx::Vertex1P1C1UV       g_vertex_buffer[g_vertex_buffer_sz];
+    const std::size_t        g_VERTEX_BUFFER_SZ = 156;
+    gfx::Vertex1P1C1UV       g_vertex_buffer[g_VERTEX_BUFFER_SZ];
 
-        UI_manager g_ui_mgr;
+    UI_manager g_ui_mgr;
 
-        const std::uint8_t UI_manager::s_max_num_canvases;
+    const std::uint8_t UI_manager::s_MAX_NUM_CANVASES;
 
-        void UI_manager::init()
-        {
-                m_num_canvases = 0;
-        }
+    void UI_manager::init()
+    {
+        m_num_canvases = 0;
+    }
 
-        Canvas * UI_manager::create_canvas(const math::Rect & rect, gfx::Sprite_atlas & atlas)
-        {
-                if (m_num_canvases >= s_max_num_canvases) {
-                        return nullptr;
-                }
-
-                void *pmem = mem::allocate(sizeof(Canvas));
-                Canvas *pcanvas = new (pmem) Canvas(rect, atlas.get_id());
-                m_canvases[m_num_canvases++].bind(*pcanvas);
-
-                return pcanvas;
-        }
-
-        void UI_manager::set_widgets_shader(gfx::Shader & widgets_shader)
-        {
-                m_pwidgets_shader = &widgets_shader;
     bool UI_manager::add_canvas(const Canvas & canvas)
     {
         if (m_num_canvases >= s_MAX_NUM_CANVASES) {
             return false;
         }
 
-        // By the default, the canvas should ocupy the entire screen
-        // maybe we should find a way to get the scene camera, and use its left, right,
-        // bottom and top values, to initialize the Canvas's rect
-        // TODO: set the Rect to be the size of the screen!!!!!
 
-        Canvas * UI_manager::create_canvas(gfx::Sprite_atlas & atlas)
-        {
-                return create_canvas(math::Rect(), atlas);
+        m_canvases[m_num_canvases++].bind(canvas);
+        return true;
+    }
+
+
+    void UI_manager::set_widgets_shader(gfx::Shader & widgets_shader)
+    {
+        m_pwidgets_shader = &widgets_shader;
+    }
+
+    void UI_manager::render()
+    {
+        std::int32_t p_location = m_pwidgets_shader->get_uniform_location("P");
+        gom::Camera_2d & level_camera = gom::g_game_object_mgr.get_main_camera();
+        m_pwidgets_shader->uniform_matrix4fv(p_location, 1, false,
+            level_camera.projection().value_ptr());
+
+        gom::Game_object *pgame_object = nullptr;
+        Canvas *pcanvas = nullptr;
+        for (std::uint8_t i = 0; i != m_num_canvases; ++i) {
+            pgame_object = gom::g_game_object_mgr.get_by_handle(m_canvases[i]);
+            if (!pgame_object) {
+                continue;
+            }
+
+            pcanvas = static_cast<Canvas*>(pgame_object);
+            if (pcanvas->is_active()) {
+                gfx::Sprite_atlas * patlas = pcanvas->get_atlas();
+                patlas->get_texture()->use();
+                pcanvas->render();
+            }
         }
+    }
 
-        void UI_manager::render()
-        {
-                std::int32_t p_location = m_pwidgets_shader->get_uniform_location("P");
-                gom::Camera_2d * plevel_camera = gom::g_game_object_mgr.get_main_camera();
-                m_pwidgets_shader->uniform_matrix4fv(p_location, 1, false,
-                                                     plevel_camera->projection().value_ptr());
-
-                gom::Game_object *pgame_object = nullptr;
-                Canvas *pcanvas = nullptr;
-                for (std::uint8_t i = 0; i != m_num_canvases; ++i) {
-                        pgame_object = gom::g_game_object_mgr.get_by_handle(m_canvases[i]);
-                        if (!pgame_object) {
-                                continue;
-                        }
-
-                        pcanvas = static_cast<Canvas*>(pgame_object);
-                        if (pcanvas->is_active()) {
-                                gfx::Sprite_atlas * patlas = pcanvas->get_atlas();
-                                patlas->get_texture()->use();
-                                pcanvas->render();
-                        }
-                }
+    void UI_manager::shut_down()
+    {
+        for (std::uint8_t i = 0; i != m_num_canvases; ++i) {
+            gom::g_game_object_mgr.request_destruction(m_canvases[i]);
         }
-
-        void UI_manager::shut_down()
-        {
-                for (std::uint8_t i = 0; i != m_num_canvases; ++i) {
-                        gom::g_game_object_mgr.request_destruction(m_canvases[i]);
-                }
-        }
+    }
 
 }

--- a/engine/source/ui/source/src/UI_manager.hpp
+++ b/engine/source/ui/source/src/UI_manager.hpp
@@ -20,13 +20,12 @@ namespace ui
 
                 UI_manager & operator=(const UI_manager &) = delete;
 
-                void            init();
-                void            shut_down();
-                void            render();
+                void    init();
+                void    shut_down();
+                void    render();
 
                 // Warning: This does not destory the canvas objects
                 void            reset() { m_num_canvases = 0; }
-
                 void            set_widgets_shader(gfx::Shader & widgets_shader);
         private:
                 static const std::uint8_t       s_max_num_canvases = 8;

--- a/engine/source/ui/source/src/UI_manager.hpp
+++ b/engine/source/ui/source/src/UI_manager.hpp
@@ -15,8 +15,6 @@ namespace ui
         class UI_manager final {
         public:
                 UI_manager() = default;
-                Canvas *        create_canvas(const math::Rect & rect, gfx::Sprite_atlas & atlas);
-                Canvas *        create_canvas(gfx::Sprite_atlas & atlas);
                 UI_manager(const UI_manager &) = delete;
 
                 UI_manager & operator=(const UI_manager &) = delete;

--- a/engine/source/ui/source/src/UI_manager.hpp
+++ b/engine/source/ui/source/src/UI_manager.hpp
@@ -23,6 +23,7 @@ namespace ui
                 void    init();
                 void    shut_down();
                 void    render();
+                bool    add_canvas(const Canvas & canvas);
 
                 // Warning: This does not destory the canvas objects
                 void            reset() { m_num_canvases = 0; }

--- a/engine/source/ui/source/src/UI_manager.hpp
+++ b/engine/source/ui/source/src/UI_manager.hpp
@@ -16,6 +16,7 @@ namespace ui
         public:
                 UI_manager() = default;
                 UI_manager(const UI_manager &) = delete;
+                ~UI_manager() = default;
 
                 UI_manager & operator=(const UI_manager &) = delete;
 

--- a/engine/source/ui/source/src/UI_manager.hpp
+++ b/engine/source/ui/source/src/UI_manager.hpp
@@ -28,9 +28,9 @@ namespace ui
                 void            reset() { m_num_canvases = 0; }
                 void            set_widgets_shader(gfx::Shader & widgets_shader);
         private:
-                static const std::uint8_t       s_max_num_canvases = 8;
+                static const std::uint8_t       s_MAX_NUM_CANVASES = 8;
                 std::uint8_t                    m_num_canvases;
-                gom::Game_object_handle         m_canvases[s_max_num_canvases];
+                gom::Game_object_handle         m_canvases[s_MAX_NUM_CANVASES];
                 gfx::Shader *                   m_pwidgets_shader;
         };
 
@@ -38,7 +38,7 @@ namespace ui
 
         // this buffer should be temporarily! the idea is to implement a stack allocator
         // and use it for the UI module as a hole
-        extern const std::size_t        g_vertex_buffer_sz;
+        extern const std::size_t        g_VERTEX_BUFFER_SZ;
         extern gfx::Vertex1P1C1UV       g_vertex_buffer[];
 }
 #endif // !_UI_MANAGER_HPP

--- a/engine/source/ui/source/src/Widget.cpp
+++ b/engine/source/ui/source/src/Widget.cpp
@@ -11,64 +11,69 @@
 
 namespace ui
 {
-        Widget::Widget(Canvas & parent_canvas) : Widget(parent_canvas, math::Rect()) {}
+    Widget::Widget(Canvas & parent_canvas) : Widget(parent_canvas, math::Rect()) {}
 
-        Widget::Widget(Canvas & parent_canvas, const math::Rect & obj_space_aabb,
-                       const std::size_t obj_sz) :
-                gom::Game_object(obj_sz, math::g_zero_vec3),
-                m_pparent_canvas(parent_canvas.add_widget(*this)),
-                m_obj_space_aabb(obj_space_aabb) {}
-
-        void Widget::update(const float dt) {}
-
-        void Widget::on_event(Event & event) {}
-
-        // TODO: Use a stack allocator instead of the static global g_vertex_buffer
-        Widget::vertex_data Widget::get_view_space_vertices() const
-        {
-                math::vec4  bottom_left_pos(m_obj_space_aabb.min());
-                math::vec4  bottom_right_pos(bottom_left_pos.x + m_obj_space_aabb.width,
-                                                   bottom_left_pos.y);
-                math::vec4  top_right_pos(m_obj_space_aabb.max());
-                math::vec4  top_left_pos(m_obj_space_aabb.x, m_obj_space_aabb.y);
-
-                const math::mat4 & view_space = m_pparent_canvas->get_transform_component()
-                                                                  .get_object_to_world();
-
-                // Transform the vertices 
-                bottom_left_pos *= view_space;
-                bottom_right_pos *= view_space;
-                top_right_pos *= view_space;
-                top_left_pos *= view_space;
-                
-                // set the buffer's data
-                gfx::Vertex1P1C1UV *pbuffer = ui::g_vertex_buffer;
-                math::vec4 widget_color(1.0f);
-                pbuffer[0].m_col = widget_color;
-                pbuffer[0].m_pos = math::vec3(bottom_left_pos.x, bottom_left_pos.y, 0.0f);
-                pbuffer[0].m_uv = math::g_zero_vec2;
-
-                pbuffer[1].m_col = widget_color;
-                pbuffer[1].m_pos = math::vec3(bottom_right_pos.x, bottom_right_pos.y, 0.0f);
-                pbuffer[1].m_uv = math::g_zero_vec2;
-
-                pbuffer[2].m_col = widget_color;
-                pbuffer[2].m_pos = math::vec3(top_right_pos.x, top_right_pos.y, 0.0f);
-                pbuffer[2].m_uv = math::g_zero_vec2;
-
-                pbuffer[3].m_col = widget_color;
-                pbuffer[3].m_pos = math::vec3(top_right_pos.x, top_right_pos.y, 0.0f);
-                pbuffer[3].m_uv = math::g_zero_vec2;
-
-                pbuffer[4].m_col = widget_color;
-                pbuffer[4].m_pos = math::vec3(top_left_pos.x, top_left_pos.y, 0.0f);
-                pbuffer[4].m_uv = math::g_zero_vec2;
-
-                pbuffer[5].m_col = widget_color;
-                pbuffer[5].m_pos = math::vec3(bottom_left_pos.x, bottom_left_pos.y, 0.0f);
-                pbuffer[5].m_uv = math::g_zero_vec2;
-
-                return std::make_pair(pbuffer, 6);
+    Widget::Widget(Canvas & parent_canvas, const math::Rect & obj_space_aabb,
+        const std::size_t obj_sz) :
+        gom::Game_object(obj_sz, math::g_zero_vec3),
+        m_pparent_canvas(nullptr),
+        m_obj_space_aabb(obj_space_aabb)
+    {
+        if (parent_canvas.add_widget(*this)) {
+            m_pparent_canvas = &parent_canvas;
         }
+    }
+
+    void Widget::update(const float dt) {}
+
+    void Widget::on_event(Event & event) {}
+
+    // TODO: Use a stack allocator instead of the static global g_vertex_buffer
+    Widget::vertex_data Widget::get_view_space_vertices() const
+    {
+        math::vec4  bottom_left_pos(m_obj_space_aabb.min());
+        math::vec4  bottom_right_pos(bottom_left_pos.x + m_obj_space_aabb.width,
+            bottom_left_pos.y);
+        math::vec4  top_right_pos(m_obj_space_aabb.max());
+        math::vec4  top_left_pos(m_obj_space_aabb.x, m_obj_space_aabb.y);
+
+        const math::mat4 & view_space = m_pparent_canvas->get_transform_component()
+            .get_object_to_world();
+
+        // Transform the vertices 
+        bottom_left_pos *= view_space;
+        bottom_right_pos *= view_space;
+        top_right_pos *= view_space;
+        top_left_pos *= view_space;
+
+        // set the buffer's data
+        gfx::Vertex1P1C1UV *pbuffer = ui::g_vertex_buffer;
+        math::vec4 widget_color(1.0f);
+        pbuffer[0].m_col = widget_color;
+        pbuffer[0].m_pos = math::vec3(bottom_left_pos.x, bottom_left_pos.y, 0.0f);
+        pbuffer[0].m_uv = math::g_zero_vec2;
+
+        pbuffer[1].m_col = widget_color;
+        pbuffer[1].m_pos = math::vec3(bottom_right_pos.x, bottom_right_pos.y, 0.0f);
+        pbuffer[1].m_uv = math::g_zero_vec2;
+
+        pbuffer[2].m_col = widget_color;
+        pbuffer[2].m_pos = math::vec3(top_right_pos.x, top_right_pos.y, 0.0f);
+        pbuffer[2].m_uv = math::g_zero_vec2;
+
+        pbuffer[3].m_col = widget_color;
+        pbuffer[3].m_pos = math::vec3(top_right_pos.x, top_right_pos.y, 0.0f);
+        pbuffer[3].m_uv = math::g_zero_vec2;
+
+        pbuffer[4].m_col = widget_color;
+        pbuffer[4].m_pos = math::vec3(top_left_pos.x, top_left_pos.y, 0.0f);
+        pbuffer[4].m_uv = math::g_zero_vec2;
+
+        pbuffer[5].m_col = widget_color;
+        pbuffer[5].m_pos = math::vec3(bottom_left_pos.x, bottom_left_pos.y, 0.0f);
+        pbuffer[5].m_uv = math::g_zero_vec2;
+
+        return std::make_pair(pbuffer, 6);
+    }
 
 }

--- a/engine/source/ui/source/src/Widget.cpp
+++ b/engine/source/ui/source/src/Widget.cpp
@@ -2,7 +2,6 @@
 #include "Canvas.hpp"
 #include "UI_manager.hpp"
 #include "Event.hpp"
-#include "Game_object.hpp"
 #include "Vertex1P1C1UV.hpp"
 #include "vec4.hpp"
 #include "mat4.hpp"

--- a/engine/source/ui/source/src/Widget.hpp
+++ b/engine/source/ui/source/src/Widget.hpp
@@ -18,22 +18,24 @@ namespace ui
                 friend class Canvas;
         public:
                 typedef std::pair<gfx::Vertex1P1C1UV *, std::size_t> vertex_data;
+                
+                explicit Widget(Canvas & parent_canvas);
+                Widget(Canvas & parent_canvas, const math::Rect & obj_space_aabb,
+                       const std::size_t obj_sz = sizeof(Widget));
+                Widget(const Widget &) = delete;
+                         
+                Widget & operator=(const Widget &) = delete;
+
+                bool has_parent() const { return (m_pparent_canvas) ? (true) : (false); }
+
+                math::Rect get_obj_space_rect() const { return m_obj_space_aabb; }
 
                 virtual void            update(const float dt) override;
                 virtual void            on_event(Event & event) override;
-                explicit Widget(Canvas & parent_canvas);
-                         Widget(Canvas & parent_canvas, const math::Rect & obj_space_aabb,
-                                const std::size_t obj_sz = sizeof(Widget));
-                         bool has_parent() const 
-                         {
-                                 return (m_pparent_canvas) ? (true) : (false);
-                         }
-
-                         math::Rect get_obj_space_rect() const { return m_obj_space_aabb; }
-                         void       set_obj_to_canvas_translation(const math::vec2 & t)
-                         {
-                                 m_obj_to_canvas_translation = t;
-                         }
+                void       set_obj_to_canvas_translation(const math::vec2 & t)
+                {
+                        m_obj_to_canvas_translation = t;
+                }
         protected:
                 virtual vertex_data     get_view_space_vertices() const;
                 // Button * pbutton_component;

--- a/engine/source/ui/source/src/Widget.hpp
+++ b/engine/source/ui/source/src/Widget.hpp
@@ -4,12 +4,12 @@
 
 #include "Game_object.hpp"
 #include "Rect.hpp"
-#include "Vertex1P1C1UV.hpp"
 #include "vec2.hpp"
 #include <cstddef>
 #include <utility>
 
 class Event;
+namespace gfx { struct Vertex1P1C1UV; }
 namespace ui { class Canvas; }
 
 namespace ui

--- a/game/source/CMakeLists.txt
+++ b/game/source/CMakeLists.txt
@@ -94,14 +94,14 @@ set(include_files src/Hover_robot.hpp src/Hover_robot_creator.hpp
 		  src/Player_idle_state.hpp src/Player_ducking_state.hpp src/Player_running_state.hpp
 		  src/Player_jumping_state.hpp src/Player_climbing_state.hpp 
 		  src/Player_taking_hit_state.hpp src/Level_ui_creator.hpp src/Pause_text.hpp
-		  src/Main_menu_creator.hpp src/game.hpp)
+		  src/Main_menu_creator.hpp src/Main_menu_canvas.hpp src/game.hpp)
 
 set(unprocessed_source_files Hover_robot.cpp  Hover_robot_creator.cpp Player.cpp
                              Player_creator.cpp Projectile_creator.cpp Player_idle_state.cpp
 		             Player_ducking_state.cpp Player_running_state.cpp 
 			     Player_jumping_state.cpp Player_climbing_state.cpp 
 			     Player_taking_hit_state.cpp Level_ui_creator.cpp Pause_text.cpp 
-			     Main_menu_creator.cpp game.cpp)
+			     Main_menu_creator.cpp Main_menu_canvas.cpp game.cpp)
 
 set(preprocessed_files "")
 preprocess_source_files("${unprocessed_source_files}" preprocessed_files

--- a/game/source/src/Level_ui_creator.cpp
+++ b/game/source/src/Level_ui_creator.cpp
@@ -22,13 +22,11 @@ Level_ui_creator::Level_ui_creator(const string_id canvas_atlas_id) :
 
 gom::Game_object * Level_ui_creator::create(const math::vec3 & wld_pos)
 {
-        math::Rect screen_rect = gom::g_game_object_mgr.get_main_camera()->get_screen_rect();
-        rms::Resource * pres = gfx::g_sprite_atlas_mgr.get_by_id(m_canvas_atlas_id);
-        gfx::Sprite_atlas * pui_atlas = static_cast<gfx::Sprite_atlas*>(pres);
+        math::Rect screen_rect = gom::g_game_object_mgr.get_main_camera().get_screen_rect();
+        void *pmem = mem::allocate(sizeof(ui::Canvas));
+        ui::Canvas *pcanvas = new (pmem) ui::Canvas(screen_rect, m_canvas_atlas_id);
 
-        ui::Canvas *pcanvas = ui::g_ui_mgr.create_canvas(screen_rect, *pui_atlas);
-
-        void * pmem = mem::allocate(sizeof(ui::Text));
+        pmem = mem::allocate(sizeof(ui::Text));
         Pause_text *ptext = new (pmem) Pause_text(*pcanvas);
         ptext->set_obj_to_canvas_translation(screen_rect.center());
         ptext->set_active(false);

--- a/game/source/src/Main_menu_canvas.cpp
+++ b/game/source/src/Main_menu_canvas.cpp
@@ -1,0 +1,15 @@
+#include "Main_menu_canvas.hpp"
+#include "Input_manager.hpp"
+#include "Level_manager.hpp"
+#include "crc32.hpp"
+
+Main_menu_canvas::Main_menu_canvas(const math::Rect & bounds, const string_id atlas_id) :
+    ui::Canvas(bounds, atlas_id, sizeof(Main_menu_canvas)) {}
+
+void Main_menu_canvas::update(float dt)
+{
+    bool start_game_pressed = io::g_input_mgr.get_button_down(SID('action'));
+    if (start_game_pressed) {
+        level_management::g_level_mgr.request_next_level();
+    }
+}

--- a/game/source/src/Main_menu_canvas.hpp
+++ b/game/source/src/Main_menu_canvas.hpp
@@ -1,0 +1,15 @@
+#ifndef _MAIN_MENU_CANVAS
+#define _MAIN_MENU_CANVAS
+
+#include "Canvas.hpp"
+#include "string_id.hpp"
+
+namespace math { struct Rect; }
+
+class Main_menu_canvas : public ui::Canvas {
+public:
+    Main_menu_canvas(const math::Rect & bounds, const string_id atlas_id);
+
+    virtual void update(float dt) override;
+};
+#endif // !_MAIN_MENU_CANVAS

--- a/game/source/src/Main_menu_creator.cpp
+++ b/game/source/src/Main_menu_creator.cpp
@@ -6,7 +6,7 @@
 #include "Rect.hpp"
 #include "Camera_2d.hpp"
 #include "Text.hpp"
-#include "Canvas.hpp"
+#include "Main_menu_canvas.hpp"
 #include "UI_manager.hpp"
 
 #include "Game_object.hpp"
@@ -20,13 +20,13 @@ Main_menu_creator::Main_menu_creator(const string_id canvas_atlas_id) :
 
 gom::Game_object * Main_menu_creator::create(const math::vec3 & wld_pos)
 {
-        math::Rect screen_rect = gom::g_game_object_mgr.get_main_camera()->get_screen_rect();
-        rms::Resource * pres = gfx::g_sprite_atlas_mgr.get_by_id(m_canvas_atlas_id);
-        gfx::Sprite_atlas * pui_atlas = static_cast<gfx::Sprite_atlas*>(pres);
-        ui::Canvas *pcanvas = ui::g_ui_mgr.create_canvas(screen_rect, *pui_atlas);
+        math::Rect screen_rect = gom::g_game_object_mgr.get_main_camera().get_screen_rect();
+
+        void *pmem = mem::allocate(sizeof(Main_menu_canvas));
+        Main_menu_canvas *pcanvas = new (pmem) Main_menu_canvas(screen_rect, m_canvas_atlas_id);
 
         
-        void * pmem = mem::allocate(sizeof(ui::Text));
+        pmem = mem::allocate(sizeof(ui::Text));
         ui::Text *ptitle = new (pmem) ui::Text(*pcanvas, "T2D ENGINE", sizeof(ui::Text), 0.5f, 5);
 
         pmem = mem::allocate(sizeof(ui::Text));

--- a/game/source/src/game.cpp
+++ b/game/source/src/game.cpp
@@ -163,6 +163,8 @@ int main(int argc, char *argv[])
                                             io::Abstract_keyboard_index::KEY_A);
         control_scheme.map_action_to_button(SID('attack_01'),
                                             io::Abstract_keyboard_index::KEY_S);
+        control_scheme.map_action_to_button(SID('action'),
+                                            io::Abstract_keyboard_index::KEY_ENTER);
 
         // Load next Level - FOR DEBUGGING
         control_scheme.map_action_to_button(SID('next_level'),

--- a/game/source/src/game.cpp
+++ b/game/source/src/game.cpp
@@ -176,8 +176,8 @@ int main(int argc, char *argv[])
         level_management::g_level_mgr.request_level(0);
 
 
-        gom::Camera_2d *pmain_camera = gom::g_game_object_mgr.get_main_camera();
-        pmain_camera->track(player_type_id);
+        gom::Camera_2d & main_camera = gom::g_game_object_mgr.get_main_camera();
+        main_camera.track(player_type_id);
 
         gfx::Window * prender_window = gfx::g_graphics_mgr.get_render_window();
 

--- a/game/source/src/game.cpp
+++ b/game/source/src/game.cpp
@@ -173,7 +173,7 @@ int main(int argc, char *argv[])
                                             io::Abstract_keyboard_index::KEY_P);
 
 
-        level_management::g_level_mgr.load_level(0);
+        level_management::g_level_mgr.request_level(0);
 
 
         gom::Camera_2d *pmain_camera = gom::g_game_object_mgr.get_main_camera();
@@ -201,7 +201,7 @@ int main(int argc, char *argv[])
                         bool next_level_pressed = io::g_input_mgr.get_button_down(SID('next_level'));
                         bool prev_level_pressed = io::g_input_mgr.get_button_down(SID('previous_level'));
                         if (next_level_pressed) {
-                                level_management::g_level_mgr.load_next_level();
+                                level_management::g_level_mgr.request_next_level();
                         }
                 }
         }


### PR DESCRIPTION
### Description
  This PR does a few refactors in some of the Engine's systems, and also creates a new Canvas class on the DEMO to be used to define the Main Menu. Following are the main changes of this PR:
  - Refactoring of the UI system to allow Canvas objects to be created directly using the constructor, i.e, the constructor is no longer private, and new classes can be Sub Classes of the Canvas class.
  - Refactoring of the Level_manager class to allow clients to request a level to be loaded, if possible, the loading will occur on the next iteration of the main loop (tick). 
  - Creation of the Main_menu_canvas to be used to create the DEMO's main menu.

[Ticket](https://app.hacknplan.com/p/68474/kanban?categoryId=0&boardId=234155&taskId=60&tabId=basicinfo)