### PR TITLE
No-61 Player death loop

### DIFF
--- a/engine/source/level_management/source/src/Level_manager.cpp
+++ b/engine/source/level_management/source/src/Level_manager.cpp
@@ -108,6 +108,10 @@ namespace level_management
 
         void Level_manager::request_level(const std::uint32_t level_index)
         {
+            if (m_should_restart) {
+                return;
+            }
+
             if (level_index > m_levels.size() - 1) {
                 return;
             }
@@ -235,8 +239,9 @@ namespace level_management
         {
             if (m_should_load_next_level) {
                 load_requested_level();
-                // reset flag
+
                 m_should_load_next_level = false;
+                m_should_restart = false;
             }
 
                 io::g_input_mgr.poll_events();
@@ -312,7 +317,8 @@ namespace level_management
                 gfx::g_graphics_mgr.swap_and_poll();
 
                 if (m_should_restart) {
-                        restart();
+                        restart_level();
+                        m_should_restart = false;
                 }
         }
 
@@ -347,9 +353,8 @@ namespace level_management
                 }
         }
 
-        void Level_manager::restart()
+        void Level_manager::restart_level()
         {
-                m_should_restart = false;
                 std::cout << "RESETING LEVEL...." << std::endl;
 
                 // reset U_manager

--- a/engine/source/level_management/source/src/Level_manager.cpp
+++ b/engine/source/level_management/source/src/Level_manager.cpp
@@ -120,6 +120,13 @@ namespace level_management
             m_should_load_next_level = true;
         }
 
+        void Level_manager::request_restart()
+        {
+            if (!m_should_load_next_level) {
+                m_should_restart = true;
+            }
+        }
+
         void Level_manager::load_resident_data(const char * pplevels[], const uint32_t num_levels,
                 Path & resources_path)
         {

--- a/engine/source/level_management/source/src/Level_manager.hpp
+++ b/engine/source/level_management/source/src/Level_manager.hpp
@@ -25,7 +25,6 @@ namespace level_management
 
                 void shut_down();
                 void tick();
-                void restart();
                 void request_restart();
                 bool is_game_clock_paused() const { return m_timer.is_paused(); }
         private:
@@ -34,6 +33,7 @@ namespace level_management
                 void            instantiate_level_objects();
                 void            unload_current_level();
                 void            load_requested_level();
+                void            restart_level();
                 Path*                                           m_presources_path = nullptr;
                 std::vector<Game_object_data>                   m_level_data;
                 Tile_map*                                       m_ptile_map;

--- a/engine/source/level_management/source/src/Level_manager.hpp
+++ b/engine/source/level_management/source/src/Level_manager.hpp
@@ -26,6 +26,7 @@ namespace level_management
                 void shut_down();
                 void tick();
                 void restart();
+                void request_restart();
                 bool is_game_clock_paused() const { return m_timer.is_paused(); }
         private:
                 void            load_objects_data();

--- a/engine/source/phy_2d/source/src/Collision_listener.hpp
+++ b/engine/source/phy_2d/source/src/Collision_listener.hpp
@@ -11,6 +11,7 @@ namespace physics_2d {
 	class Collision_listener {
 	public:
 		virtual void begin_body_collision(Body_2d * pbody_a, Body_2d * pbody_b) const = 0;
+        virtual void in_body_collision(Body_2d * pbody_a, Body_2d * pbody_b) const = 0;
 		virtual void end_body_collision(Body_2d * pbody_a, Body_2d * pbody_b) const = 0;
 
 		//virtual void begin_tile_collision(Body_2d & b, const AABB_2d & tile_aabb) const = 0;

--- a/engine/source/phy_2d/source/src/World.cpp
+++ b/engine/source/phy_2d/source/src/World.cpp
@@ -897,8 +897,10 @@ void physics_2d::World::update(const float dt)
 		//check if bodies types allow collision, i.e, at least one should be dynamic
 		Body_2d *pbody_a = pcollider_proxy_a->pcollider->get_body();
 		Body_2d *pbody_b = pcollider_proxy_b->pcollider->get_body();
+        const Body_2d::Entity_types body_a_type = pbody_a->get_type();
+        const Body_2d::Entity_types body_b_type = pbody_b->get_type();
 
-		if (pbody_a->get_type() != Body_2d::DYNAMIC && pbody_b->get_type() != Body_2d::DYNAMIC) {
+		if (body_a_type != Body_2d::DYNAMIC && body_b_type != Body_2d::DYNAMIC) {
 			continue;
 		}
 
@@ -915,12 +917,21 @@ void physics_2d::World::update(const float dt)
 				break;
 			}
 		}
+        
 		if (!is_duplicate) {
 			// new pair of colliding Collider_2ds, add it to the contact list
 			add_to_contact_list(pcollider_proxy_a, pcollider_proxy_b);
 			// CALL BEGING CONTACT ON THE BODY_2DS !!! USE CONTACT LISTENER
-			m_pcoll_listener->begin_body_collision(pcollider_proxy_a->pcollider->get_body(), pcollider_proxy_b->pcollider->get_body());
+			m_pcoll_listener->begin_body_collision(pbody_a, pbody_b);
 		}
+        else if (pcollider_proxy_a->pcollider->is_trigger() || pcollider_proxy_b->pcollider->is_trigger()) {
+            m_pcoll_listener->in_body_collision(pbody_a, pbody_b);
+
+        }
+        else if ((body_a_type == Body_2d::DYNAMIC) && (body_b_type == Body_2d::DYNAMIC)) {
+            m_pcoll_listener->in_body_collision(pbody_a, pbody_b);
+        }
+
 	}
 
 	//-----------------------NARROWPHASE: SOLVE COLLISIONS---------------------------------------

--- a/engine/source/src/Engine_collision_listener.cpp
+++ b/engine/source/src/Engine_collision_listener.cpp
@@ -8,6 +8,7 @@
 Engine_collision_listener::Engine_collision_listener()
 {
        m_begin_collision_id = get_crc32("EVENT_BEGIN_COLLISION");
+       m_in_collision_id = get_crc32("EVENT_IN_COLLISION");
        m_end_collision_id = get_crc32("EVENT_END_COLLISION");
        m_game_object_id = get_crc32("game_object_id");
        m_game_object_handle_index = get_crc32("game_object_handle_index");
@@ -33,6 +34,16 @@ void Engine_collision_listener::begin_body_collision(physics_2d::Body_2d * pbody
 
         send_collision_event(pgame_object_a, pgame_object_b, m_begin_collision_id);
         send_collision_event(pgame_object_b, pgame_object_a, m_begin_collision_id);
+}
+
+void Engine_collision_listener::in_body_collision(physics_2d::Body_2d * pbody_a,
+                                                  physics_2d::Body_2d * pbody_b) const
+{
+        gom::Game_object  *pgame_object_a = static_cast<gom::Game_object*>(pbody_a->get_user_data());
+        gom::Game_object  *pgame_object_b = static_cast<gom::Game_object*>(pbody_b->get_user_data());
+
+        send_collision_event(pgame_object_a, pgame_object_b, m_in_collision_id);
+        send_collision_event(pgame_object_b, pgame_object_a, m_in_collision_id);
 }
 
 void Engine_collision_listener::end_body_collision(physics_2d::Body_2d * pbody_a,

--- a/engine/source/src/Engine_collision_listener.hpp
+++ b/engine/source/src/Engine_collision_listener.hpp
@@ -6,17 +6,24 @@
 namespace physics_2d { class Body_2d; }
 namespace gom { class Game_object; }
 
-class Engine_collision_listener : public physics_2d::Collision_listener {
+class Engine_collision_listener final : public physics_2d::Collision_listener {
 public:
         Engine_collision_listener();
-        void begin_body_collision(physics_2d::Body_2d * pbody_a, physics_2d::Body_2d * pbody_b) const override;
-        void end_body_collision(physics_2d::Body_2d * pbody_a, physics_2d::Body_2d * pbody_b) const override;
+        void begin_body_collision(physics_2d::Body_2d * pbody_a,
+                                  physics_2d::Body_2d * pbody_b) const override;
+
+        void in_body_collision(physics_2d::Body_2d * pbody_a,
+                               physics_2d::Body_2d * pbody_b) const override;
+
+        void end_body_collision(physics_2d::Body_2d * pbody_a,
+                                physics_2d::Body_2d * pbody_b) const override;
 private:
         void  send_collision_event(gom::Game_object * pfrom_object, 
                                    gom::Game_object * pto_object,
                                    std::uint32_t event_type) const;
 
         std::uint32_t           m_begin_collision_id;
+        std::uint32_t           m_in_collision_id;
         std::uint32_t           m_end_collision_id;
         std::uint32_t           m_game_object_id;
         std::uint32_t           m_game_object_handle_index;

--- a/engine/source/ui/source/src/UI_manager.cpp
+++ b/engine/source/ui/source/src/UI_manager.cpp
@@ -40,14 +40,15 @@ namespace ui
     void UI_manager::set_widgets_shader(gfx::Shader & widgets_shader)
     {
         m_pwidgets_shader = &widgets_shader;
+        // TODO: Remove hardcoded value
+        m_projection_location = m_pwidgets_shader->get_uniform_location("P");
     }
 
     void UI_manager::render()
     {
-        std::int32_t p_location = m_pwidgets_shader->get_uniform_location("P");
         gom::Camera_2d & level_camera = gom::g_game_object_mgr.get_main_camera();
-        m_pwidgets_shader->uniform_matrix4fv(p_location, 1, false,
-            level_camera.projection().value_ptr());
+        m_pwidgets_shader->uniform_matrix4fv(m_projection_location, 1, false,
+                                             level_camera.projection().value_ptr());
 
         gom::Game_object *pgame_object = nullptr;
         Canvas *pcanvas = nullptr;

--- a/engine/source/ui/source/src/UI_manager.hpp
+++ b/engine/source/ui/source/src/UI_manager.hpp
@@ -31,6 +31,7 @@ namespace ui
         private:
                 static const std::uint8_t       s_MAX_NUM_CANVASES = 8;
                 std::uint8_t                    m_num_canvases;
+                std::int32_t                    m_projection_location;
                 gom::Game_object_handle         m_canvases[s_MAX_NUM_CANVASES];
                 gfx::Shader *                   m_pwidgets_shader;
         };

--- a/game/source/src/Hover_robot.cpp
+++ b/game/source/src/Hover_robot.cpp
@@ -38,6 +38,7 @@ Hover_robot::Hover_robot(std::size_t object_sz, atlas_n_layer & sprite_data,
 void Hover_robot::on_event(Event & event)
 {
         switch (event.get_type()) {
+        case SID('EVENT_IN_COLLISION'):
         case SID('EVENT_BEGIN_COLLISION'): {
                 // Get colliding Game Object
                 const Variant *phandle_arg = event.get_arguments()

--- a/game/source/src/Player.cpp
+++ b/game/source/src/Player.cpp
@@ -97,7 +97,13 @@ void Player::update(const float dt)
             level_management::g_level_mgr.request_restart();
         }
     }
+    else if (m_is_in_invincibiliy_mode) {
+        m_utility_timer += dt;
+        if (m_utility_timer >= s_NUM_SECONDS_IN_INVINCIBILIY_MODE) {
+            m_is_in_invincibiliy_mode = false;
+            m_utility_timer = 0.0f;
         }
+    }
 
 
     if (!level_management::g_level_mgr.is_game_clock_paused()) {

--- a/game/source/src/Player.cpp
+++ b/game/source/src/Player.cpp
@@ -31,6 +31,7 @@ Player::Player(std::size_t object_sz, atlas_n_layer & sprite_data,
     m_health = 100;
     m_taking_hit = false;
     m_is_player_dead = false;
+    m_utility_timer = 0.0f;
 }
 
 

--- a/game/source/src/Player.cpp
+++ b/game/source/src/Player.cpp
@@ -30,6 +30,7 @@ Player::Player(std::size_t object_sz, atlas_n_layer & sprite_data,
 	m_pstate = static_cast<gom::Gameplay_state*>(new (pmem) Player_idle_state());
     m_health = 100;
     m_taking_hit = false;
+    m_is_player_dead = false;
 }
 
 

--- a/game/source/src/Player.cpp
+++ b/game/source/src/Player.cpp
@@ -80,6 +80,13 @@ void Player::on_event(Event & event)
 
     }
 }
+
+void Player::start_invincibiliy_mode()
+{
+    if (!m_is_in_invincibiliy_mode) {
+        m_is_in_invincibiliy_mode = true;
+        m_utility_timer = 0.0f;
+    }
 }
 
 void Player::update(const float dt) 

--- a/game/source/src/Player.cpp
+++ b/game/source/src/Player.cpp
@@ -22,6 +22,8 @@
 
 
 unsigned Player::s_NUM_SECONDS_TO_RESPAWN = 2;
+unsigned Player::s_NUM_SECONDS_IN_INVINCIBILIY_MODE = 1;
+
 Player::Player(std::size_t object_sz, atlas_n_layer & sprite_data,
                physics_2d::Body_2d_def *pbody_def, const gfx::Animator_controller *pcontroller,
                bool facing_left) :

--- a/game/source/src/Player.cpp
+++ b/game/source/src/Player.cpp
@@ -21,6 +21,7 @@
 #include <iostream>
 
 
+unsigned Player::s_NUM_SECONDS_TO_RESPAWN = 2;
 Player::Player(std::size_t object_sz, atlas_n_layer & sprite_data,
                physics_2d::Body_2d_def *pbody_def, const gfx::Animator_controller *pcontroller,
                bool facing_left) :

--- a/game/source/src/Player.cpp
+++ b/game/source/src/Player.cpp
@@ -34,6 +34,7 @@ Player::Player(std::size_t object_sz, atlas_n_layer & sprite_data,
     m_health = 100;
     m_taking_hit = false;
     m_is_player_dead = false;
+    m_is_in_invincibiliy_mode = false;
     m_utility_timer = 0.0f;
 }
 

--- a/game/source/src/Player.hpp
+++ b/game/source/src/Player.hpp
@@ -26,6 +26,7 @@ private:
 
         // used to count time elapsed after important events
         float           m_utility_timer;
+        static  unsigned s_NUM_SECONDS_TO_RESPAWN;
 };
 
 

--- a/game/source/src/Player.hpp
+++ b/game/source/src/Player.hpp
@@ -23,6 +23,7 @@ public:
 private:
         bool            m_taking_hit;
         bool            m_is_player_dead;
+        bool            m_is_in_invincibiliy_mode;
 
         // used to count time elapsed after important events
         float           m_utility_timer;

--- a/game/source/src/Player.hpp
+++ b/game/source/src/Player.hpp
@@ -24,6 +24,8 @@ private:
         bool            m_taking_hit;
         bool            m_is_player_dead;
 
+        // used to count time elapsed after important events
+        float           m_utility_timer;
 };
 
 

--- a/game/source/src/Player.hpp
+++ b/game/source/src/Player.hpp
@@ -20,6 +20,7 @@ public:
         void            set_taking_hit(const bool taking_hit) { m_taking_hit = taking_hit; }
         void            on_event(Event & event) override;
         bool            is_player_dead() const { return m_is_player_dead; }
+        void            start_invincibiliy_mode();
 private:
         bool            m_taking_hit;
         bool            m_is_player_dead;

--- a/game/source/src/Player.hpp
+++ b/game/source/src/Player.hpp
@@ -28,6 +28,7 @@ private:
         // used to count time elapsed after important events
         float           m_utility_timer;
         static  unsigned s_NUM_SECONDS_TO_RESPAWN;
+        static  unsigned s_NUM_SECONDS_IN_INVINCIBILIY_MODE;
 };
 
 

--- a/game/source/src/Player.hpp
+++ b/game/source/src/Player.hpp
@@ -19,8 +19,10 @@ public:
         bool            is_taking_hit() const { return m_taking_hit; }
         void            set_taking_hit(const bool taking_hit) { m_taking_hit = taking_hit; }
         void            on_event(Event & event) override;
+        bool            is_player_dead() const { return m_is_player_dead; }
 private:
         bool            m_taking_hit;
+        bool            m_is_player_dead;
 
 };
 

--- a/game/source/src/Player_taking_hit_state.cpp
+++ b/game/source/src/Player_taking_hit_state.cpp
@@ -32,18 +32,28 @@ Player_taking_hit_state::Player_taking_hit_state(gom::Actor & actor, float jump_
 
 gom::Gameplay_state * Player_taking_hit_state::handle_input(gom::Actor & actor) 
 {
-        bool on_ground = physics_2d::g_physics_mgr.get_world()->is_body_2d_on_ground(actor.get_body_2d_component());
-        if (on_ground) {
-                //set the paramter on the animation state machine to make the transition to the new animation
-                Player *pplayer = static_cast<Player*>(&actor);
-                pplayer->set_taking_hit(false);
-                actor.get_anim_controller_component()->set_bool(SID('is_taking_hit'), false);
-                actor.get_body_2d_component()->stop_movement_x();
+    physics_2d::World * pworld = physics_2d::g_physics_mgr.get_world();
+    bool on_ground = pworld->is_body_2d_on_ground(actor.get_body_2d_component());
+    if (on_ground) {
+        actor.get_body_2d_component()->stop_movement_x();
+        Player *pplayer = static_cast<Player*>(&actor);
+        pplayer->set_taking_hit(false);
+        bool is_player_dead = pplayer->is_player_dead();
+        if (!is_player_dead) {
+            // Set paramter on animation state machine to make the transition to the new animation
+            actor.get_anim_controller_component()->set_bool(SID('is_taking_hit'), false);
+            // start invincibility mode
+            pplayer->start_invincibiliy_mode();
 
-                void *pmem = mem::allocate(sizeof(Player_idle_state));
-                return static_cast<gom::Gameplay_state*> (new (pmem) Player_idle_state);
+            void *pmem = mem::allocate(sizeof(Player_idle_state));
+            return static_cast<gom::Gameplay_state*> (new (pmem) Player_idle_state);
         }
-        return nullptr;
+        else {
+            return nullptr;
+        }
+
+    }
+    return nullptr;
 }
 
 

--- a/game/source/src/Projectile_creator.cpp
+++ b/game/source/src/Projectile_creator.cpp
@@ -51,7 +51,6 @@ gom::Game_object *Projectile_creator::create(const math::vec3 & wld_pos)
 
 	physics_2d::Collider_2d_def coll_def;
 	coll_def.m_aabb = m_pbody_def->m_aabb;
-	coll_def.m_is_trigger = true;
 
     std::size_t object_sz = sizeof(gom::Projectile);
     void *pmem = mem::allocate(object_sz);


### PR DESCRIPTION
## Summary
 The Player and Player_taking_hit classes were refactored to allow the level to restart after the player's health goes to zero, and to give the player a small window of time in which it cannot take any damage after taking a hit. It was also necessary to add a new callback function to the Collision_listener, to be able to notify game objects that they are still colliding, i.e, the collision continues after a begin_collision_event. This fixes a but that allowed the player to 'stay glued' to an enemy and don't receive any more collision events.

[Ticket](https://app.hacknplan.com/p/68474/kanban?categoryId=0&boardId=234155&taskId=61&tabId=basicinfo) 